### PR TITLE
Fix typo in release workflow

### DIFF
--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -2,7 +2,7 @@ name: Publish to the Marketplace
 
 on:
   release:
-    action: [released]
+    types: [released]
 
 jobs:
   publish_to_marketplace:


### PR DESCRIPTION
There is a typo in the release workflow, preventing the publication on the marketplace to be triggered only one time, and ONLY if we make a release (not a pre-release)