### PR TITLE
Remove uneeded properties from main class

### DIFF
--- a/ps_accounts.php
+++ b/ps_accounts.php
@@ -42,56 +42,6 @@ class Ps_accounts extends Module
     public $adminControllers;
 
     /**
-     * @var string
-     */
-    public $author;
-
-    /**
-     * @var bool
-     */
-    public $bootstrap;
-
-    /**
-     * @var int
-     */
-    public $need_instance;
-
-    /**
-     * @var string
-     */
-    public $description;
-
-    /**
-     * @var string
-     */
-    public $confirmUninstall;
-
-    /**
-     * @var string
-     */
-    public $displayName;
-
-    /**
-     * @var string
-     */
-    public $name;
-
-    /**
-     * @var array
-     */
-    public $ps_versions_compliancy;
-
-    /**
-     * @var string
-     */
-    public $tab;
-
-    /**
-     * @var string
-     */
-    public $version;
-
-    /**
      * @var \Monolog\Logger
      */
     private $logger;


### PR DESCRIPTION
Some properties are already defined in the Module class of the core.
It seems they are also defined in the ps_accounts main class to fix some PHPStan errors about misleading types, but this issue has been fixed a few months ago with https://github.com/PrestaShop/php-dev-tools/pull/35.

On the other hand, keeping these properties may trigger errors in some case, as I got on my shop. This PR fixes it.

![image](https://user-images.githubusercontent.com/6768917/109171807-66dac800-7782-11eb-8a60-85515fbfb1dc.png)
