### PR TITLE
fix: cast token to string in legacy methods of PsAccountsService

### DIFF
--- a/classes/Service/PsAccountsService.php
+++ b/classes/Service/PsAccountsService.php
@@ -97,7 +97,7 @@ class PsAccountsService
      */
     public function getOrRefreshToken()
     {
-        return $this->shopTokenRepository->getOrRefreshToken();
+        return (string) $this->shopTokenRepository->getOrRefreshToken();
     }
 
     /**
@@ -113,7 +113,7 @@ class PsAccountsService
      */
     public function getToken()
     {
-        return $this->shopTokenRepository->getToken();
+        return (string) $this->shopTokenRepository->getToken();
     }
 
     /**


### PR DESCRIPTION
Typehint say it's a string but an object was returned by the new TokenRepository