### PR TITLE
feat: rename old V4 function

### DIFF
--- a/classes/Service/PsAccountsService.php
+++ b/classes/Service/PsAccountsService.php
@@ -82,6 +82,7 @@ class PsAccountsService
 
     /**
      * @deprecated deprecated since version 5.0
+     *
      * @return string|false
      */
     public function getShopUuidV4()


### PR DESCRIPTION
Je renomme la fonction pour ne pas trainer un nom de version inutile.
On aura uniquement la fonction getShopUuid dans la doc
related to https://github.com/PrestaShopCorp/prestashop-accounts-installer/pull/4