### PR TITLE
fix: disable tailwind preflight

### DIFF
--- a/_dev/tailwind.config.js
+++ b/_dev/tailwind.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   important: true,
+  corePlugins: {
+    preflight: false,
+  },
   prefix: "tw-",
   purge: {
     content: ["./src/**/*.vue"],


### PR DESCRIPTION
Aims to remove the preflight from TailwindCSS, to no longer inject unscoped CSS reset in applications that use PSAccount.

This PR follows the problem encountered on Metrics and Legal, and reported in the #customer-platfom channel on Slack by @guillaumeArgiles.

