### PR TITLE
Account 1475/fix/get real backoffice url

### DIFF
--- a/ps_accounts.php
+++ b/ps_accounts.php
@@ -445,21 +445,21 @@ class Ps_accounts extends Module
             /** @var \PrestaShop\Module\PsAccounts\Adapter\Link $link */
             $link = $this->getService(\PrestaShop\Module\PsAccounts\Adapter\Link::class);
 
-            Cache::clean('Shop::setUrl_' . (int) $params['object']->id_shop);
+            Cache::clean('Shop::setUrl_' . (int) $params['object']->id);
 
-            $shop = new \Shop($params['object']->id_shop);
+            $shop = new \Shop($params['object']->id);
 
             $domain = $params['object']->domain;
             $sslDomain = $params['object']->domain_ssl;
 
             $response = $accountsApi->updateUserShop(new \PrestaShop\Module\PsAccounts\DTO\UpdateShop([
-                'shopId' => (string) $params['object']->id_shop,
+                'shopId' => (string) $params['object']->id,
                 'name' => $shop->name,
                 'domain' => 'http://' . $domain,
                 'sslDomain' => 'https://' . $sslDomain,
                 'physicalUri' => $params['object']->physical_uri,
                 'virtualUri' => $params['object']->virtual_uri,
-                'boBaseUrl' => $link->changeDomainOfAdminLink(
+                'boBaseUrl' => $link->getAdminLinkWithCustomDomain(
                     $sslDomain,
                     $domain,
                     'AdminModules',
@@ -467,7 +467,7 @@ class Ps_accounts extends Module
                     [],
                     [
                         'configure' => $this->name,
-                        'setShopContext' => 's-' . $params['object']->id_shop,
+                        'setShopContext' => 's-' . $params['object']->id,
                     ]
                 ),
             ]));
@@ -526,7 +526,7 @@ class Ps_accounts extends Module
             'sslDomain' => 'https://' . $shop->domain_ssl,
             'physicalUri' => $shop->physical_uri,
             'virtualUri' => $shop->virtual_uri,
-            'boBaseUrl' => $link->changeDomainOfAdminLink(
+            'boBaseUrl' => $link->getAdminLinkWithCustomDomain(
                 $sslDomain,
                 $domain,
                 'AdminModules',
@@ -534,7 +534,7 @@ class Ps_accounts extends Module
                 [],
                 [
                     'configure' => $this->name,
-                    'setShopContext' => 's-' . $params['object']->id_shop,
+                    'setShopContext' => 's-' . $params['object']->id,
                 ]
             ),
         ]));

--- a/src/Adapter/Link.php
+++ b/src/Adapter/Link.php
@@ -97,7 +97,7 @@ class Link
      *
      * @return string
      */
-    public function changeDomainOfAdminLink($sslDomain, $domain, $controller, $withToken = true, $sfRouteParams = [], $params = [])
+    public function getAdminLinkWithCustomDomain($sslDomain, $domain, $controller, $withToken = true, $sfRouteParams = [], $params = [])
     {
         $boBaseUrl = $this->getAdminLink($controller, $withToken, $sfRouteParams, $params);
         $parsedUrl = parse_url($boBaseUrl);


### PR DESCRIPTION
The boBaseUrl wasn't up to date in the hook, there are no "proper" way to do that in prestashop (or i didn't find it).
I just replaced the domain given in the boBaseUrl given by prestashop.