### PR TITLE
chore: deprecate gae staging for preprod new url

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -11,9 +11,9 @@ parameters:
 
   ps_accounts.accounts_api_url: 'https://accounts-api.prestashop.localhost/v1/'
   ps_accounts.accounts_ui_url: 'https://accounts.prestashop.localhost'
-  ps_accounts.sso_api_url: 'https://prestashop-newsso-staging.appspot.com/api/v1/'
-  ps_accounts.sso_account_url: 'https://prestashop-newsso-staging.appspot.com/login'
-  ps_accounts.sso_resend_verification_email_url: 'https://prestashop-newsso-staging.appspot.com/account/send-verification-email'
+  ps_accounts.sso_api_url: 'https://auth-preprod.prestashop.com/api/v1/'
+  ps_accounts.sso_account_url: 'https://authv2-preprod.prestashop.com/login'
+  ps_accounts.sso_resend_verification_email_url: 'https://auth-preprod.prestashop.com/account/send-verification-email'
   ps_accounts.billing_api_url: 'https://billing-api.psessentials-integration.net'
   ps_accounts.sentry_credentials: 'https://4c7f6c8dd5aa405b8401a35f5cf26ada@o298402.ingest.sentry.io/5354585'
   ps_accounts.segment_write_key: 'UITzSdsFTgYsXaiJG09hsCiupUPwgJQB'


### PR DESCRIPTION
By chance, does anyone know where is stored the secret vault for the preprod build config?