### PR TITLE
[ACCOUNT-2044] Allow only once call of refresh token by script execution

### DIFF
--- a/src/Repository/AbstractTokenRepository.php
+++ b/src/Repository/AbstractTokenRepository.php
@@ -117,11 +117,9 @@ abstract class AbstractTokenRepository
             return $this->getToken();
         }
 
-        if (isset($this->refreshTokenCalled[$refreshToken]) && $this->refreshTokenCalled[$refreshToken]) {
+        if ($this->getRefreshTokenCalled($refreshToken)) {
             return $this->getToken();
         }
-
-        $this->refreshTokenCalled[$refreshToken] = true;
 
         if (true === $forceRefresh || $this->isTokenExpired()) {
             try {
@@ -133,6 +131,7 @@ abstract class AbstractTokenRepository
             } catch (RefreshTokenException $e) {
                 Logger::getInstance()->debug($e);
             }
+            $this->setRefreshTokenCalled($refreshToken);
         }
 
         return $this->getToken();
@@ -255,5 +254,25 @@ abstract class AbstractTokenRepository
         $service = $module->getService(ShopLinkAccountService::class);
 
         $service->resetLinkAccount();
+    }
+
+    /**
+     * @param string $refreshToken
+     *
+     * @return bool
+     */
+    protected function getRefreshTokenCalled(string $refreshToken): bool
+    {
+        return isset($this->refreshTokenCalled[$refreshToken]) && $this->refreshTokenCalled[$refreshToken];
+    }
+
+    /**
+     * @param string $refreshToken
+     *
+     * @return void
+     */
+    protected function setRefreshTokenCalled(string $refreshToken): void
+    {
+        $this->refreshTokenCalled[$refreshToken] = true;
     }
 }


### PR DESCRIPTION
- Allow only once call of refresh token during a script execution
- Can be useful for PrestaShopCorp/api.accounts.prestashop.com#366 (the same thing can be done on SSO for user tokens)