### PR TITLE
Check that account exists before removing it

### DIFF
--- a/src/Hook/ActionObjectEmployeeDeleteAfter.php
+++ b/src/Hook/ActionObjectEmployeeDeleteAfter.php
@@ -39,7 +39,9 @@ class ActionObjectEmployeeDeleteAfter extends Hook
         $repository = new EmployeeAccountRepository();
         try {
             $employeeAccount = $repository->findByEmployeeId($employee->id);
-            $repository->delete($employeeAccount);
+            if ($employeeAccount) {
+                $repository->delete($employeeAccount);
+            }
         } catch (\Exception $e) {
         }
     }


### PR DESCRIPTION
# What problem this PR is trying to solve?

The UI tests for the future classic edition V9 detected some errors, when an employee is deleted if it is not associated to an EmployeeAccount the returned object is null which is incompatible with `EmployeeAccountRepository::delete` and it triggers an error.

# How can anyone reproduce the issue?

Install ps_accounts on 9.0.x, create a new employee, delete it right away the error is triggered (but the employee is still removed after). The problem may exist on other versions, and it's also possible that it was not detected on PHP7* and only recently with version 8+ that are stricter regarding the types.

# Which version of the module is impacted?

7.0.8

# Description of this PR changes

Check that the object is not null.