### PR TITLE
fix: disable init content for api controllers

### DIFF
--- a/src/Api/Controller/AbstractRestController.php
+++ b/src/Api/Controller/AbstractRestController.php
@@ -67,6 +67,13 @@ abstract class AbstractRestController extends ModuleFrontController
 
     /**
      * @return void
+     */
+    public function initContent()
+    {
+    }
+
+    /**
+     * @return void
      *
      * @throws \PrestaShopException
      */


### PR DESCRIPTION
As suggested by the merchant in this issue : [ACCOUNT-2729](https://forge.prestashop.com/browse/ACCOUNT-2729?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D), we override `initContent` with an empty method to avoid triggering hooks.
As a consequence we also avoid related warnings and invalid response JSON.