### PR TITLE
[ACCOUNT-2797] fix: onLoginFailedRedirect triggers logout on next login

### DIFF
--- a/controllers/admin/AdminOAuth2PsAccountsController.php
+++ b/controllers/admin/AdminOAuth2PsAccountsController.php
@@ -199,6 +199,14 @@ class AdminOAuth2PsAccountsController extends \ModuleAdminController
     }
 
     /**
+     * @return mixed
+     */
+    protected function onLoginFailedRedirect()
+    {
+        $this->logout();
+    }
+
+    /**
      * @return SessionInterface
      */
     protected function getSession()

--- a/src/AccountLogin/OAuth2LoginTrait.php
+++ b/src/AccountLogin/OAuth2LoginTrait.php
@@ -280,7 +280,10 @@ trait OAuth2LoginTrait
         $this->oauth2ErrorLog($e->getMessage());
         $this->setLoginError($e->getType());
 
-        return $this->logout();
+        return $this->redirect(
+            $this->getSessionReturnTo() ?:
+                $this->link->getAdminLink('AdminDashboard')
+        );
     }
 
     /**

--- a/src/AccountLogin/OAuth2LoginTrait.php
+++ b/src/AccountLogin/OAuth2LoginTrait.php
@@ -61,6 +61,11 @@ trait OAuth2LoginTrait
     abstract protected function logout();
 
     /**
+     * @return mixed
+     */
+    abstract protected function onLoginFailedRedirect();
+
+    /**
      * @return SessionInterface
      */
     abstract protected function getSession();
@@ -280,10 +285,7 @@ trait OAuth2LoginTrait
         $this->oauth2ErrorLog($e->getMessage());
         $this->setLoginError($e->getType());
 
-        return $this->redirect(
-            $this->getSessionReturnTo() ?:
-                $this->link->getAdminLink('AdminDashboard')
-        );
+        return $this->onLoginFailedRedirect();
     }
 
     /**

--- a/src/Controller/Admin/OAuth2Controller.php
+++ b/src/Controller/Admin/OAuth2Controller.php
@@ -245,6 +245,17 @@ class OAuth2Controller extends FrameworkBundleAdminController
     }
 
     /**
+     * @return RedirectResponse
+     */
+    protected function onLoginFailedRedirect()
+    {
+        return $this->redirect(
+            $this->getSessionReturnTo() ?:
+                $this->link->getAdminLink('AdminDashboard')
+        );
+    }
+
+    /**
      * @return SessionInterface
      */
     protected function getSession()


### PR DESCRIPTION
- Redirect to logout on login failure will result to a redirect logout on next login success (yeah :exploding_head:)
- Instead we redirect to the Dashboard that will be stored for next `return_to` after login & redirect to login on failure