### PR TITLE
fix: remove client credentials redirect_uri parameter

### DIFF
--- a/src/Service/OAuth2/OAuth2Service.php
+++ b/src/Service/OAuth2/OAuth2Service.php
@@ -247,7 +247,7 @@ class OAuth2Service
                     'client_secret' => $this->oAuth2Client->getClientSecret(),
                     'scope' => implode(' ', $scope),
                     'audience' => implode(' ', $audience),
-                    'redirect_uri' => $this->getOAuth2Client()->getRedirectUri(),
+                    //'redirect_uri' => $this->getOAuth2Client()->getRedirectUri(),
                 ],
             ]
         );


### PR DESCRIPTION
Maybe not include `redirect_uri` it if it's perfectly useless in `client_credentials` mode: 
see: https://www.ory.sh/docs/troubleshooting/mandatory-redirect-uri