### PR TITLE
[ACCOUNT-3038] feat: context with empty status

### DIFF
--- a/src/Provider/ShopProvider.php
+++ b/src/Provider/ShopProvider.php
@@ -349,7 +349,8 @@ class ShopProvider
                     function () use (&$shops, $shopData, $refresh) {
                         $shopUrl = $this->getUrl((int) $shopData['id_shop']);
                         try {
-                            $shopStatus = $this->shopStatus->getStatus($refresh);
+                            $cacheTtl = $refresh ? 0 : StatusManager::CACHE_TTL;
+                            $shopStatus = $this->shopStatus->getStatus(false, $cacheTtl);
                         } catch (UnknownStatusException $e) {
                             $shopStatus = new ShopStatus([
                                 'frontendUrl' => $shopUrl->getFrontendUrl(),

--- a/src/Provider/ShopProvider.php
+++ b/src/Provider/ShopProvider.php
@@ -351,7 +351,9 @@ class ShopProvider
                         try {
                             $shopStatus = $this->shopStatus->getStatus($refresh);
                         } catch (UnknownStatusException $e) {
-                            $shopStatus = new ShopStatus();
+                            $shopStatus = new ShopStatus([
+                                'frontendUrl' => $shopUrl->getFrontendUrl(),
+                            ]);
                         }
                         $identifyPointOfContactUrl = $this->oAuth2Service->getOAuth2Client()->getRedirectUri([
                             'action' => 'identifyPointOfContact',

--- a/src/Provider/ShopProvider.php
+++ b/src/Provider/ShopProvider.php
@@ -21,11 +21,13 @@
 namespace PrestaShop\Module\PsAccounts\Provider;
 
 use PrestaShop\Module\PsAccounts\Account\Dto\Shop;
+use PrestaShop\Module\PsAccounts\Account\Exception\UnknownStatusException;
 use PrestaShop\Module\PsAccounts\Account\Session\Firebase\OwnerSession;
 use PrestaShop\Module\PsAccounts\Account\ShopUrl;
 use PrestaShop\Module\PsAccounts\Account\StatusManager;
 use PrestaShop\Module\PsAccounts\Adapter\Link;
 use PrestaShop\Module\PsAccounts\Context\ShopContext;
+use PrestaShop\Module\PsAccounts\Service\Accounts\Resource\ShopStatus;
 use PrestaShop\Module\PsAccounts\Service\OAuth2\OAuth2Service;
 
 class ShopProvider
@@ -346,7 +348,11 @@ class ShopProvider
                     $shopData['id_shop'],
                     function () use (&$shops, $shopData, $refresh) {
                         $shopUrl = $this->getUrl((int) $shopData['id_shop']);
-                        $shopStatus = $this->shopStatus->getStatus($refresh);
+                        try {
+                            $shopStatus = $this->shopStatus->getStatus($refresh);
+                        } catch (UnknownStatusException $e) {
+                            $shopStatus = new ShopStatus();
+                        }
                         $identifyPointOfContactUrl = $this->oAuth2Service->getOAuth2Client()->getRedirectUri([
                             'action' => 'identifyPointOfContact',
                         ]);

--- a/src/Service/Accounts/AccountsService.php
+++ b/src/Service/Accounts/AccountsService.php
@@ -124,7 +124,10 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response, 'Unable to get deprecated tokens', 'store-identity/unable-to-get-deprecated-tokens');
+            throw new AccountsException($response,
+                'Unable to get firebase tokens',
+                'store-identity/unable-to-get-deprecated-tokens'
+            );
         }
 
         return new FirebaseTokens($response->body);
@@ -153,7 +156,10 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response, 'Unable to refresh shop token', 'store/unable-to-refresh-shop-token');
+            throw new AccountsException($response,
+                'Unable to refresh firebase shop token',
+                'store/unable-to-refresh-shop-token'
+            );
         }
 
         return new LegacyFirebaseToken($response->body);
@@ -253,7 +259,10 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response, 'Unable to create shop identity', 'store-identity/unable-to-create-shop-identity');
+            throw new AccountsException($response,
+                'Unable to create shop identity',
+                'store-identity/unable-to-create-shop-identity'
+            );
         }
 
         return new IdentityCreated($response->body);
@@ -288,7 +297,10 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response, 'Unable to verify shop identity', 'store-identity/unable-to-verify-shop-identity');
+            throw new AccountsException($response,
+                'Unable to verify shop identity',
+                'store-identity/unable-to-verify-shop-identity'
+            );
         }
     }
 
@@ -313,7 +325,10 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response, 'Unable to retrieve shop status', 'store-identity/unable-to-retrieve-shop-status');
+            throw new AccountsException($response,
+                'Unable to retrieve shop status',
+                'store-identity/unable-to-retrieve-shop-status'
+            );
         }
 
         return new ShopStatus($response->body);
@@ -344,7 +359,10 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response, 'Unable to set point of contact', 'store-identity/unable-to-set-point-of-contact');
+            throw new AccountsException($response,
+                'Unable to set point of contact',
+                'store-identity/unable-to-set-point-of-contact'
+            );
         }
     }
 
@@ -379,7 +397,10 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response, 'Unable to migrate shop identity', 'store-identity/unable-to-migrate-shop-identity');
+            throw new AccountsException($response,
+                'Unable to migrate shop identity',
+                'store-identity/unable-to-migrate-shop-identity'
+            );
         }
 
         return new IdentityCreated($response->body);

--- a/src/Service/Accounts/AccountsService.php
+++ b/src/Service/Accounts/AccountsService.php
@@ -124,10 +124,7 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response,
-                'Unable to get firebase tokens',
-                'store-identity/unable-to-get-deprecated-tokens'
-            );
+            throw new AccountsException($response, 'Unable to get firebase tokens', 'store-identity/unable-to-get-deprecated-tokens');
         }
 
         return new FirebaseTokens($response->body);
@@ -156,10 +153,7 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response,
-                'Unable to refresh firebase shop token',
-                'store/unable-to-refresh-shop-token'
-            );
+            throw new AccountsException($response, 'Unable to refresh firebase shop token', 'store/unable-to-refresh-shop-token');
         }
 
         return new LegacyFirebaseToken($response->body);
@@ -259,10 +253,7 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response,
-                'Unable to create shop identity',
-                'store-identity/unable-to-create-shop-identity'
-            );
+            throw new AccountsException($response, 'Unable to create shop identity', 'store-identity/unable-to-create-shop-identity');
         }
 
         return new IdentityCreated($response->body);
@@ -297,10 +288,7 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response,
-                'Unable to verify shop identity',
-                'store-identity/unable-to-verify-shop-identity'
-            );
+            throw new AccountsException($response, 'Unable to verify shop identity', 'store-identity/unable-to-verify-shop-identity');
         }
     }
 
@@ -325,10 +313,7 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response,
-                'Unable to retrieve shop status',
-                'store-identity/unable-to-retrieve-shop-status'
-            );
+            throw new AccountsException($response, 'Unable to retrieve shop status', 'store-identity/unable-to-retrieve-shop-status');
         }
 
         return new ShopStatus($response->body);
@@ -359,10 +344,7 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response,
-                'Unable to set point of contact',
-                'store-identity/unable-to-set-point-of-contact'
-            );
+            throw new AccountsException($response, 'Unable to set point of contact', 'store-identity/unable-to-set-point-of-contact');
         }
     }
 
@@ -397,10 +379,7 @@ class AccountsService
         );
 
         if (!$response->isSuccessful) {
-            throw new AccountsException($response,
-                'Unable to migrate shop identity',
-                'store-identity/unable-to-migrate-shop-identity'
-            );
+            throw new AccountsException($response, 'Unable to migrate shop identity', 'store-identity/unable-to-migrate-shop-identity');
         }
 
         return new IdentityCreated($response->body);


### PR DESCRIPTION
Includes a default ShopStatus into context in order to display verify button even when cloud status is unknown.

Resolves: [ACCOUNT-3038](https://forge.prestashop.com/browse/ACCOUNT-3038)

- Sync with PrestaShopCorp/accounts#279