### PR TITLE
fix: multishop ps_configuration orphan rows — cleanup + prevention

### DIFF
--- a/_dev/package.json
+++ b/_dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ps_accounts",
-  "version": "8.0.15",
+  "version": "8.0.14",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/_dev/package.json
+++ b/_dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ps_accounts",
-  "version": "8.0.13",
+  "version": "8.0.15",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_accounts</name>
     <displayName><![CDATA[PrestaShop Account]]></displayName>
-    <version><![CDATA[8.0.13]]></version>
+    <version><![CDATA[8.0.15]]></version>
     <description><![CDATA[Link your store to your PrestaShop account to activate and manage your subscriptions in your back office. Do not uninstall this module if you have a current subscription.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[administration]]></tab>

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_accounts</name>
     <displayName><![CDATA[PrestaShop Account]]></displayName>
-    <version><![CDATA[8.0.15]]></version>
+    <version><![CDATA[8.0.14]]></version>
     <description><![CDATA[Link your store to your PrestaShop account to activate and manage your subscriptions in your back office. Do not uninstall this module if you have a current subscription.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[administration]]></tab>

--- a/ps_accounts.php
+++ b/ps_accounts.php
@@ -33,7 +33,7 @@ class Ps_accounts extends Module
 
     // Needed in order to retrieve the module version easier (in api call headers) than instanciate
     // the module each time to get the version
-    const VERSION = '8.0.13';
+    const VERSION = '8.0.15';
 
     /**
      * Admin tabs
@@ -97,7 +97,7 @@ class Ps_accounts extends Module
 
         // We cannot use the const VERSION because the const is not computed by addons marketplace
         // when the zip is uploaded
-        $this->version = '8.0.13';
+        $this->version = '8.0.15';
 
         $this->module_key = 'abf2cd758b4d629b2944d3922ef9db73';
 

--- a/ps_accounts.php
+++ b/ps_accounts.php
@@ -33,7 +33,7 @@ class Ps_accounts extends Module
 
     // Needed in order to retrieve the module version easier (in api call headers) than instanciate
     // the module each time to get the version
-    const VERSION = '8.0.15';
+    const VERSION = '8.0.14';
 
     /**
      * Admin tabs
@@ -97,7 +97,7 @@ class Ps_accounts extends Module
 
         // We cannot use the const VERSION because the const is not computed by addons marketplace
         // when the zip is uploaded
-        $this->version = '8.0.15';
+        $this->version = '8.0.14';
 
         $this->module_key = 'abf2cd758b4d629b2944d3922ef9db73';
 

--- a/src/Adapter/ConfigurationKeys.php
+++ b/src/Adapter/ConfigurationKeys.php
@@ -58,4 +58,32 @@ class ConfigurationKeys extends Enum
     const PS_PSX_FIREBASE_REFRESH_DATE = 'PS_PSX_FIREBASE_REFRESH_DATE';
     /* @deprecated */
     const PS_PSX_FIREBASE_EMAIL = 'PS_PSX_FIREBASE_EMAIL';
+
+    /**
+     * Subset of keys that hold transient credentials (OAuth2 access tokens and Firebase
+     * id/refresh tokens). Recoverable through a normal refresh cycle, so safe to target
+     * with destructive multishop cleanup SQL. Identifiers, OAuth2 client credentials and
+     * email keys are intentionally excluded.
+     */
+    const TOKEN_KEYS = [
+        self::PS_ACCOUNTS_ACCESS_TOKEN,
+        self::PS_ACCOUNTS_FIREBASE_ID_TOKEN,
+        self::PS_ACCOUNTS_FIREBASE_REFRESH_TOKEN,
+        self::PS_ACCOUNTS_USER_FIREBASE_ID_TOKEN,
+        self::PS_ACCOUNTS_USER_FIREBASE_REFRESH_TOKEN,
+        self::PS_PSX_FIREBASE_ID_TOKEN,
+        self::PS_PSX_FIREBASE_REFRESH_TOKEN,
+    ];
+
+    /**
+     * Override Enum::cases() to keep only scalar key constants and exclude metadata
+     * arrays such as TOKEN_KEYS, which otherwise leak through ReflectionClass::getConstants()
+     * and break callers that join the result into a SQL string list.
+     *
+     * @return array<string, string>
+     */
+    public static function cases()
+    {
+        return array_filter(parent::cases(), 'is_string');
+    }
 }

--- a/src/Context/ShopContext.php
+++ b/src/Context/ShopContext.php
@@ -168,8 +168,11 @@ class ShopContext
      */
     public function execInShopContext($shopId, $closure)
     {
-        $backup = $this->configuration->getShopId();
+        $backupShopId = $this->configuration->getShopId();
+        $backupShopGroupId = $this->configuration->getShopGroupId();
+
         $this->configuration->setShopId($shopId);
+        $this->configuration->setShopGroupId($this->resolveShopGroupId($shopId));
 
         $exception = null;
         $result = null;
@@ -181,13 +184,35 @@ class ShopContext
         } catch (\Exception $exception) {
         }
 
-        $this->configuration->setShopId($backup);
+        $this->configuration->setShopId($backupShopId);
+        $this->configuration->setShopGroupId($backupShopGroupId);
 
         if (null !== $exception) {
             throw $exception;
         }
 
         return $result;
+    }
+
+    /**
+     * Resolve the id_shop_group for a given $shopId by reading ps_shop. Without this,
+     * configuration writes performed inside the closure persist with id_shop_group taken
+     * from the surrounding context (often NULL when the caller is in CONTEXT_ALL), which
+     * desynchronises (id_shop, id_shop_group) tuples in ps_configuration and breaks the
+     * \Configuration::get cascade on subsequent reads.
+     *
+     * @param int|null $shopId
+     *
+     * @return int|null
+     */
+    private function resolveShopGroupId($shopId)
+    {
+        if (null === $shopId) {
+            return null;
+        }
+        $shop = new \Shop((int) $shopId);
+
+        return null === $shop->id_shop_group ? null : (int) $shop->id_shop_group;
     }
 
     /**

--- a/src/Repository/ConfigurationRepository.php
+++ b/src/Repository/ConfigurationRepository.php
@@ -367,8 +367,9 @@ class ConfigurationRepository
         );
 
         if ($isMultishopActive) {
-            $this->cleanupShadowedConfigurationRows($keysList);
-            $this->normalizeOrphanShopGroupRows($keysList);
+            $tokenKeysList = "'" . join("','", ConfigurationKeys::TOKEN_KEYS) . "'";
+            $this->cleanupShadowedConfigurationRows($tokenKeysList);
+            $this->normalizeOrphanShopGroupRows($tokenKeysList);
         }
     }
 

--- a/src/Repository/ConfigurationRepository.php
+++ b/src/Repository/ConfigurationRepository.php
@@ -358,11 +358,63 @@ class ConfigurationRepository
 
         $shopIdCondition = $isMultishopActive ? (int) $defaultShop->id : 'NULL';
         $shopGroupIdCondition = $isMultishopActive ? (int) $defaultShop->id_shop_group : 'NULL';
+        $keysList = "'" . join("','", array_values(ConfigurationKeys::cases())) . "'";
 
         \Db::getInstance()->query(
             'UPDATE ' . _DB_PREFIX_ . 'configuration SET id_shop = ' . $shopIdCondition . ', id_shop_group = ' . $shopGroupIdCondition .
-            " WHERE name IN('" . join("','", array_values(ConfigurationKeys::cases())) . "')" .
+            ' WHERE name IN(' . $keysList . ')' .
             ' AND id_shop ' . ($isMultishopActive ? 'IS NULL' : '= ' . (int) $defaultShop->id)
+        );
+
+        if ($isMultishopActive) {
+            $this->cleanupShadowedConfigurationRows($keysList);
+            $this->normalizeOrphanShopGroupRows($keysList);
+        }
+    }
+
+    /**
+     * Remove rows with an empty value that duplicate a populated row for the same (name, id_shop).
+     *
+     * Writes performed before PR #605 could persist a row with id_shop_group NULL because the
+     * Configuration adapter constructor did not capture id_shop_group at the time. Subsequent
+     * writes — after the capture was fixed — created a second row with id_shop_group set. The
+     * legacy \Configuration::get cascade matches on (id_shop) first and returns the empty row,
+     * never falling back to the populated one with id_shop_group set.
+     *
+     * @param string $keysList SQL-quoted, comma-separated configuration key names
+     *
+     * @return void
+     */
+    private function cleanupShadowedConfigurationRows($keysList)
+    {
+        \Db::getInstance()->query(
+            'DELETE c1 FROM ' . _DB_PREFIX_ . 'configuration c1' .
+            ' INNER JOIN ' . _DB_PREFIX_ . 'configuration c2' .
+            '   ON c1.name = c2.name' .
+            '   AND c1.id_shop = c2.id_shop' .
+            '   AND (c1.value IS NULL OR c1.value = \'\')' .
+            '   AND c2.value IS NOT NULL AND c2.value != \'\'' .
+            ' WHERE c1.name IN(' . $keysList . ')'
+        );
+    }
+
+    /**
+     * Align id_shop_group on the actual ps_shop value for rows that have id_shop defined
+     * but id_shop_group NULL — residues of writes performed before PR #605.
+     *
+     * @param string $keysList SQL-quoted, comma-separated configuration key names
+     *
+     * @return void
+     */
+    private function normalizeOrphanShopGroupRows($keysList)
+    {
+        \Db::getInstance()->query(
+            'UPDATE ' . _DB_PREFIX_ . 'configuration c' .
+            ' INNER JOIN ' . _DB_PREFIX_ . 'shop s ON c.id_shop = s.id_shop' .
+            ' SET c.id_shop_group = s.id_shop_group' .
+            ' WHERE c.name IN(' . $keysList . ')' .
+            ' AND c.id_shop_group IS NULL' .
+            ' AND c.id_shop IS NOT NULL'
         );
     }
 

--- a/tests/src/Unit/Adapter/ConfigurationKeys/CasesTest.php
+++ b/tests/src/Unit/Adapter/ConfigurationKeys/CasesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PrestaShop\Module\PsAccounts\Tests\Unit\Adapter\ConfigurationKeys;
+
+use PrestaShop\Module\PsAccounts\Adapter\ConfigurationKeys;
+use PrestaShop\Module\PsAccounts\Tests\TestCase;
+
+class CasesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itShouldOnlyReturnScalarKeyConstants()
+    {
+        $cases = ConfigurationKeys::cases();
+
+        foreach ($cases as $name => $value) {
+            $this->assertIsString($value, sprintf('case "%s" should be a string, got %s', $name, gettype($value)));
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldExcludeTheTokenKeysMetadataArrayFromCases()
+    {
+        $cases = ConfigurationKeys::cases();
+
+        $this->assertArrayNotHasKey('TOKEN_KEYS', $cases);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldStillExposeTokenKeysAsAClassConstant()
+    {
+        $this->assertIsArray(ConfigurationKeys::TOKEN_KEYS);
+        $this->assertNotEmpty(ConfigurationKeys::TOKEN_KEYS);
+        $this->assertContains(ConfigurationKeys::PS_ACCOUNTS_ACCESS_TOKEN, ConfigurationKeys::TOKEN_KEYS);
+    }
+}

--- a/tests/src/Unit/Context/ShopContext/ExecInShopContextTest.php
+++ b/tests/src/Unit/Context/ShopContext/ExecInShopContextTest.php
@@ -50,4 +50,69 @@ class ExecInShopContextTest extends TestCase
 
         $this->assertEquals($origShopId, $this->configuration->getIdShop());
     }
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function itShouldSetAndRestoreShopGroupContext()
+    {
+        /** @var ShopContext $shopContext */
+        $shopContext = $this->module->getService(ShopContext::class);
+
+        $origShopGroupId = $this->configuration->getIdShopGroup();
+        $shopId = (int) \Shop::getContextShopID(true) ?: 1;
+        $expectedGroupId = (int) (new \Shop($shopId))->id_shop_group;
+
+        $shopContext->execInShopContext($shopId, function () use ($expectedGroupId) {
+            $this->assertEquals($expectedGroupId, $this->configuration->getIdShopGroup());
+        });
+
+        $this->assertEquals($origShopGroupId, $this->configuration->getIdShopGroup());
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function itShouldRestoreShopGroupContextOnException()
+    {
+        /** @var ShopContext $shopContext */
+        $shopContext = $this->module->getService(ShopContext::class);
+
+        $origShopGroupId = $this->configuration->getIdShopGroup();
+        $shopId = (int) \Shop::getContextShopID(true) ?: 1;
+
+        try {
+            $shopContext->execInShopContext($shopId, function () {
+                throw new \Exception('closure failed');
+            });
+        } catch (\Exception $e) {
+        }
+
+        $this->assertEquals($origShopGroupId, $this->configuration->getIdShopGroup());
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function itShouldResolveShopGroupIdFromPsShopNotFromCurrentContext()
+    {
+        /** @var ShopContext $shopContext */
+        $shopContext = $this->module->getService(ShopContext::class);
+
+        // simulate a CONTEXT_ALL caller: id_shop_group unset on the adapter
+        $this->configuration->setIdShopGroup(null);
+
+        $shopId = (int) \Shop::getContextShopID(true) ?: 1;
+        $expectedGroupId = (int) (new \Shop($shopId))->id_shop_group;
+
+        $shopContext->execInShopContext($shopId, function () use ($expectedGroupId) {
+            $this->assertEquals($expectedGroupId, $this->configuration->getIdShopGroup());
+        });
+    }
 }

--- a/tests/src/Unit/Repository/ConfigurationRespository/FixMultiShopConfigTest.php
+++ b/tests/src/Unit/Repository/ConfigurationRespository/FixMultiShopConfigTest.php
@@ -150,15 +150,23 @@ class FixMultiShopConfigTest extends TestCase
         $repo = $this->module->getService(ConfigurationRepository::class);
         $idShop = $this->probeShopId();
 
-        // Shape that the multishop branch would normally fix — but it must not fire here.
+        // Shape the multishop helpers would otherwise clean up. The single-shop branch
+        // does run the inherited UPDATE from #605 (rewriting matching rows toward NULL/NULL),
+        // so we can't assert on (id_shop, id_shop_group) coordinates — we only assert that
+        // no row is *deleted*, which is what cleanupShadowedConfigurationRows would do if
+        // it ran.
+        $countBefore = $this->countRowsForName(self::KEY);
         $this->seedRow(self::KEY, '', $idShop, null);
         $this->seedRow(self::KEY, 'populated', $idShop, 1);
+        $this->assertSame($countBefore + 2, $this->countRowsForName(self::KEY), 'sanity: both rows are seeded');
 
         $repo->fixMultiShopConfig(true);
 
-        // single-shop branch only touches rows with id_shop = defaultShop.id and resets them to NULL/NULL
-        // it does NOT call cleanupShadowedConfigurationRows nor normalizeOrphanShopGroupRows
-        $this->assertNotNull($this->fetchValue(self::KEY, $idShop, 1), 'shadow row should remain since the multishop helpers do not run');
+        $this->assertSame(
+            $countBefore + 2,
+            $this->countRowsForName(self::KEY),
+            'cleanupShadowedConfigurationRows must not run in single-shop mode'
+        );
     }
 
     /**
@@ -200,6 +208,18 @@ class FixMultiShopConfigTest extends TestCase
             'INSERT INTO ' . _DB_PREFIX_ . 'configuration' .
             ' (name, value, id_shop, id_shop_group, date_add, date_upd)' .
             ' VALUES ("' . pSQL($name) . '", "' . pSQL($value) . '", ' . $shopExpr . ', ' . $groupExpr . ', NOW(), NOW())'
+        );
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return int
+     */
+    private function countRowsForName($name)
+    {
+        return (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'configuration WHERE name = "' . pSQL($name) . '"'
         );
     }
 

--- a/tests/src/Unit/Repository/ConfigurationRespository/FixMultiShopConfigTest.php
+++ b/tests/src/Unit/Repository/ConfigurationRespository/FixMultiShopConfigTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace PrestaShop\Module\PsAccounts\Tests\Unit\Repository\ConfigurationRespository;
+
+use PrestaShop\Module\PsAccounts\Adapter\ConfigurationKeys;
+use PrestaShop\Module\PsAccounts\Repository\ConfigurationRepository;
+use PrestaShop\Module\PsAccounts\Tests\TestCase;
+
+class FixMultiShopConfigTest extends TestCase
+{
+    const KEY = ConfigurationKeys::PS_ACCOUNTS_ACCESS_TOKEN;
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function itShouldSkipWhenNotForcedAndContextMatchesActualState()
+    {
+        /** @var ConfigurationRepository $repo */
+        $repo = $this->module->getService(ConfigurationRepository::class);
+        $idShop = $this->probeShopId();
+
+        $this->seedRow(self::KEY, '', $idShop, null);
+
+        $repo->fixMultiShopConfig(false);
+
+        // Without force, when isFeatureActive() === isMultishopActive() the function returns early
+        // and no UPDATE on id_shop_group nor DELETE of shadow rows is performed.
+        $this->assertNotNull($this->fetchValue(self::KEY, $idShop, null));
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function itShouldDeleteShadowRowsWithEmptyValueDuplicatingAPopulatedRow()
+    {
+        if (!\Shop::isFeatureActive()) {
+            $this->markTestSkipped('multishop branch requires Shop::isFeatureActive()');
+        }
+
+        /** @var ConfigurationRepository $repo */
+        $repo = $this->module->getService(ConfigurationRepository::class);
+        $idShop = $this->probeShopId();
+        $idShopGroup = $this->probeShopGroupId($idShop);
+
+        // shadow row (empty value, id_shop_group NULL)
+        $this->seedRow(self::KEY, '', $idShop, null);
+        // populated row (same shop, id_shop_group set)
+        $this->seedRow(self::KEY, 'populated-jwt-value', $idShop, $idShopGroup);
+
+        $repo->fixMultiShopConfig(true);
+
+        $this->assertNull($this->fetchValue(self::KEY, $idShop, null), 'shadow row should be deleted');
+        $this->assertSame('populated-jwt-value', $this->fetchValue(self::KEY, $idShop, $idShopGroup), 'populated row remains intact');
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function itShouldNormalizeOrphanShopGroupIdToPsShopValue()
+    {
+        if (!\Shop::isFeatureActive()) {
+            $this->markTestSkipped('multishop branch requires Shop::isFeatureActive()');
+        }
+
+        /** @var ConfigurationRepository $repo */
+        $repo = $this->module->getService(ConfigurationRepository::class);
+        $idShop = $this->probeShopId();
+        $expectedGroupId = $this->probeShopGroupId($idShop);
+
+        $this->seedRow(self::KEY, 'populated-jwt-value', $idShop, null);
+
+        $repo->fixMultiShopConfig(true);
+
+        $this->assertNull($this->fetchValue(self::KEY, $idShop, null), 'orphan row no longer matches id_shop_group=NULL');
+        $this->assertSame('populated-jwt-value', $this->fetchValue(self::KEY, $idShop, $expectedGroupId), 'row was migrated to actual ps_shop.id_shop_group');
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function itShouldNotTouchRowsForKeysNotOwnedByTheModule()
+    {
+        if (!\Shop::isFeatureActive()) {
+            $this->markTestSkipped('multishop branch requires Shop::isFeatureActive()');
+        }
+
+        /** @var ConfigurationRepository $repo */
+        $repo = $this->module->getService(ConfigurationRepository::class);
+        $idShop = $this->probeShopId();
+        $foreignKey = 'PS_FOREIGN_TEST_KEY_' . $this->faker->numberBetween(10000, 99999);
+
+        // identical pathological shape on a foreign key — must be left untouched
+        $this->seedRow($foreignKey, '', $idShop, null);
+        $this->seedRow($foreignKey, 'foreign-value', $idShop, $this->probeShopGroupId($idShop));
+
+        $repo->fixMultiShopConfig(true);
+
+        $this->assertSame('', (string) $this->fetchValue($foreignKey, $idShop, null), 'foreign shadow row should remain');
+        $this->assertSame('foreign-value', $this->fetchValue($foreignKey, $idShop, $this->probeShopGroupId($idShop)), 'foreign populated row should remain');
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function itShouldNotRunMultishopHelpersWhenShopFeatureInactive()
+    {
+        if (\Shop::isFeatureActive()) {
+            $this->markTestSkipped('single-shop branch requires !Shop::isFeatureActive()');
+        }
+
+        /** @var ConfigurationRepository $repo */
+        $repo = $this->module->getService(ConfigurationRepository::class);
+        $idShop = $this->probeShopId();
+
+        // Shape that the multishop branch would normally fix — but it must not fire here.
+        $this->seedRow(self::KEY, '', $idShop, null);
+        $this->seedRow(self::KEY, 'populated', $idShop, 1);
+
+        $repo->fixMultiShopConfig(true);
+
+        // single-shop branch only touches rows with id_shop = defaultShop.id and resets them to NULL/NULL
+        // it does NOT call cleanupShadowedConfigurationRows nor normalizeOrphanShopGroupRows
+        $this->assertNotNull($this->fetchValue(self::KEY, $idShop, 1), 'shadow row should remain since the multishop helpers do not run');
+    }
+
+    /**
+     * @return int
+     */
+    private function probeShopId()
+    {
+        $id = (int) \Shop::getContextShopID(true);
+        if ($id <= 0) {
+            $id = (int) (new \Shop(1))->id ?: 1;
+        }
+        return $id;
+    }
+
+    /**
+     * @param int $idShop
+     *
+     * @return int
+     */
+    private function probeShopGroupId($idShop)
+    {
+        $group = (int) (new \Shop($idShop))->id_shop_group;
+        return $group ?: 1;
+    }
+
+    /**
+     * @param string $name
+     * @param string $value
+     * @param int|null $idShop
+     * @param int|null $idShopGroup
+     *
+     * @return void
+     */
+    private function seedRow($name, $value, $idShop, $idShopGroup)
+    {
+        $shopExpr = null === $idShop ? 'NULL' : (int) $idShop;
+        $groupExpr = null === $idShopGroup ? 'NULL' : (int) $idShopGroup;
+        \Db::getInstance()->execute(
+            'INSERT INTO ' . _DB_PREFIX_ . 'configuration' .
+            ' (name, value, id_shop, id_shop_group, date_add, date_upd)' .
+            ' VALUES ("' . pSQL($name) . '", "' . pSQL($value) . '", ' . $shopExpr . ', ' . $groupExpr . ', NOW(), NOW())'
+        );
+    }
+
+    /**
+     * @param string $name
+     * @param int|null $idShop
+     * @param int|null $idShopGroup
+     *
+     * @return string|null
+     */
+    private function fetchValue($name, $idShop, $idShopGroup)
+    {
+        $shopExpr = null === $idShop ? 'id_shop IS NULL' : 'id_shop = ' . (int) $idShop;
+        $groupExpr = null === $idShopGroup ? 'id_shop_group IS NULL' : 'id_shop_group = ' . (int) $idShopGroup;
+        $row = \Db::getInstance()->getRow(
+            'SELECT value FROM ' . _DB_PREFIX_ . 'configuration' .
+            ' WHERE name = "' . pSQL($name) . '"' .
+            ' AND ' . $shopExpr .
+            ' AND ' . $groupExpr
+        );
+        return is_array($row) && array_key_exists('value', $row) ? $row['value'] : null;
+    }
+}

--- a/tests/src/Unit/Repository/ConfigurationRespository/FixMultiShopConfigTest.php
+++ b/tests/src/Unit/Repository/ConfigurationRespository/FixMultiShopConfigTest.php
@@ -112,6 +112,34 @@ class FixMultiShopConfigTest extends TestCase
      *
      * @throws \Exception
      */
+    public function itShouldNotTouchNonTokenModuleKeysEvenWhenShadowedInMultishop()
+    {
+        if (!\Shop::isFeatureActive()) {
+            $this->markTestSkipped('multishop branch requires Shop::isFeatureActive()');
+        }
+
+        /** @var ConfigurationRepository $repo */
+        $repo = $this->module->getService(ConfigurationRepository::class);
+        $idShop = $this->probeShopId();
+        $idShopGroup = $this->probeShopGroupId($idShop);
+        $nonTokenKey = ConfigurationKeys::PS_ACCOUNTS_OAUTH2_CLIENT_ID;
+
+        // exact pathological shape — but the helpers must skip this key because credentials
+        // are not recoverable through a refresh cycle the way tokens are
+        $this->seedRow($nonTokenKey, '', $idShop, null);
+        $this->seedRow($nonTokenKey, 'recoverable-client-id', $idShop, $idShopGroup);
+
+        $repo->fixMultiShopConfig(true);
+
+        $this->assertSame('', (string) $this->fetchValue($nonTokenKey, $idShop, null), 'non-token shadow row must remain (helpers must not touch it)');
+        $this->assertSame('recoverable-client-id', $this->fetchValue($nonTokenKey, $idShop, $idShopGroup), 'non-token populated row remains intact');
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
     public function itShouldNotRunMultishopHelpersWhenShopFeatureInactive()
     {
         if (\Shop::isFeatureActive()) {

--- a/upgrade/upgrade-8.0.14.php
+++ b/upgrade/upgrade-8.0.14.php
@@ -1,5 +1,7 @@
 <?php
 
+use PrestaShop\Module\PsAccounts\Repository\ConfigurationRepository;
+
 /**
  * @param Ps_accounts $module
  *
@@ -13,6 +15,10 @@ function upgrade_module_8_0_14($module)
     require_once __DIR__ . '/helpers.php';
 
     migrate_or_create_identities_v8($module);
+
+    /** @var ConfigurationRepository $configurationRepository */
+    $configurationRepository = $module->getService(ConfigurationRepository::class);
+    $configurationRepository->fixMultiShopConfig(true);
 
     return true;
 }

--- a/upgrade/upgrade-8.0.14.php
+++ b/upgrade/upgrade-8.0.14.php
@@ -1,7 +1,5 @@
 <?php
 
-use PrestaShop\Module\PsAccounts\Repository\ConfigurationRepository;
-
 /**
  * @param Ps_accounts $module
  *

--- a/upgrade/upgrade-8.0.14.php
+++ b/upgrade/upgrade-8.0.14.php
@@ -10,7 +10,7 @@ use PrestaShop\Module\PsAccounts\Repository\ConfigurationRepository;
  * @throws Exception
  * @throws Throwable
  */
-function upgrade_module_8_0_15($module)
+function upgrade_module_8_0_14($module)
 {
     /** @var ConfigurationRepository $configurationRepository */
     $configurationRepository = $module->getService(ConfigurationRepository::class);

--- a/upgrade/upgrade-8.0.14.php
+++ b/upgrade/upgrade-8.0.14.php
@@ -12,9 +12,9 @@ use PrestaShop\Module\PsAccounts\Repository\ConfigurationRepository;
  */
 function upgrade_module_8_0_14($module)
 {
-    /** @var ConfigurationRepository $configurationRepository */
-    $configurationRepository = $module->getService(ConfigurationRepository::class);
-    $configurationRepository->fixMultiShopConfig(true);
+    require_once __DIR__ . '/helpers.php';
+
+    migrate_or_create_identities_v8($module);
 
     return true;
 }

--- a/upgrade/upgrade-8.0.15.php
+++ b/upgrade/upgrade-8.0.15.php
@@ -1,0 +1,20 @@
+<?php
+
+use PrestaShop\Module\PsAccounts\Repository\ConfigurationRepository;
+
+/**
+ * @param Ps_accounts $module
+ *
+ * @return bool
+ *
+ * @throws Exception
+ * @throws Throwable
+ */
+function upgrade_module_8_0_15($module)
+{
+    /** @var ConfigurationRepository $configurationRepository */
+    $configurationRepository = $module->getService(ConfigurationRepository::class);
+    $configurationRepository->fixMultiShopConfig(true);
+
+    return true;
+}


### PR DESCRIPTION
## Summary

This PR addresses two distinct but related issues that lead to inconsistent `(id_shop, id_shop_group)` tuples on `PS_ACCOUNTS_*` keys in `ps_configuration`:

1. **Existing orphan rows** — rows written before #605 have `id_shop` set but `id_shop_group` NULL. Subsequent writes (after that PR fixed the constructor capture) created a second row with `id_shop_group` set. The legacy `\Configuration::get` cascade matches on `(id_shop)` first and returns the empty row, never falling back to the populated one. Downstream code (Token parsing) then reads empty values and enters an infinite refresh loop on tokens that are actually persisted correctly in another row.
2. **Structural cause that keeps regenerating them** — `ShopContext::execInShopContext` switches `id_shop` but not `id_shop_group`. When the surrounding context is `CONTEXT_ALL`, the initial `id_shop_group` is NULL/0, and any `setToken()` inside the closure persists with `id_shop_group` NULL even though `id_shop` is correctly switched.

Without (2), (1) is a one-shot cleanup — the same orphan rows are regenerated at the next multi-shop iteration.

## Changes

**Cleanup (commit 1)** — `ConfigurationRepository::fixMultiShopConfig` + new upgrade script:
- `cleanupShadowedConfigurationRows`: `DELETE` empty rows that duplicate a populated row for the same `(name, id_shop)`
- `normalizeOrphanShopGroupRows`: `UPDATE id_shop_group` to the actual `ps_shop.id_shop_group` value for remaining orphan rows
- `upgrade/upgrade-8.0.15.php` to run the migration on a routine module upgrade (existing call sites only fire on install, explicit reset, or shop add/delete)

**Prevention (commit 2)** — `ShopContext::execInShopContext`:
- Back up and restore `id_shop_group` alongside `id_shop`
- Resolve the target `id_shop_group` from `ps_shop` for the given `$shopId` so writes inside the closure persist with the correct tuple

## Context

- Builds on #605 — same pattern, extended to:
  - The inverse data shape: rows with `id_shop` defined but `id_shop_group` NULL (cleanup)
  - The remaining behavioural gap: `execInShopContext` only switching one of the two dimensions (prevention)
- Different cause from #635 (token expiration leeway). #635 addresses real clock skew, this PR addresses a write/read asymmetry in `ps_configuration` rows. The two can ship independently
- Reproduces on multishop installs whose first writes happened before #605 (i.e. shops upgraded from < 8.0.13 to 8.0.13+ without an explicit module reset)
- Version `8.0.15` is a placeholder — to align with the team based on the merge order with #635

## Test plan

- [ ] `make phpunit-run-unit`
- [ ] Manual on a multishop staging with shadow rows in `ps_configuration` for `PS_ACCOUNTS_*` keys: dump table before, run upgrade, verify shadow rows are gone and populated rows remain
- [ ] On a multishop staging, exercise a code path that goes through `execInShopContext` for a non-default shop (typically the back-office `formatShopData` flow), then `SELECT id_shop, id_shop_group ... FROM ps_configuration WHERE name LIKE 'PS_ACCOUNTS_%'` and verify writes land with `id_shop_group` set to the shop's actual group, not NULL
- [ ] Verify single-shop install: multishop branch in `fixMultiShopConfig` is skipped — no-op
- [ ] Verify multishop install without shadow rows: `DELETE` matches nothing, `UPDATE` matches nothing — no-op
- [ ] Verify `Token::isValid: token isExpired` log line count drops to near zero on shops that were looping pre-upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)