### PR TITLE
[ACC-3389] fix(upgrade): register PS_ACCOUNTS_LAST_UPGRADE with explicit version on PS9 zip upgrade

### DIFF
--- a/src/Account/Command/MigrateOrCreateIdentitiesV8Command.php
+++ b/src/Account/Command/MigrateOrCreateIdentitiesV8Command.php
@@ -23,9 +23,24 @@ namespace PrestaShop\Module\PsAccounts\Account\Command;
 
 use PrestaShop\Module\PsAccounts\Traits\WithOriginAndSourceTrait;
 
+/**
+ * @method $this withVersion(string|null $version)
+ * @method string|null getVersion(bool $restoreDefault = true)
+ */
 class MigrateOrCreateIdentitiesV8Command
 {
     use WithOriginAndSourceTrait;
+
+    /**
+     * Explicit target version to register once the migration succeeds.
+     *
+     * Sourced from the upgrade script (always-fresh code) so we do not rely on the
+     * possibly-stale \Ps_accounts::VERSION const during a zip upgrade. Null falls back
+     * to the const downstream (BC).
+     *
+     * @var string|null
+     */
+    public $version;
 
     public function __construct()
     {

--- a/src/Account/Command/MigrateOrCreateIdentityV8Command.php
+++ b/src/Account/Command/MigrateOrCreateIdentityV8Command.php
@@ -23,6 +23,10 @@ namespace PrestaShop\Module\PsAccounts\Account\Command;
 
 use PrestaShop\Module\PsAccounts\Traits\WithOriginAndSourceTrait;
 
+/**
+ * @method $this withVersion(string|null $version)
+ * @method string|null getVersion(bool $restoreDefault = true)
+ */
 class MigrateOrCreateIdentityV8Command
 {
     use WithOriginAndSourceTrait;
@@ -31,6 +35,17 @@ class MigrateOrCreateIdentityV8Command
      * @var int|null
      */
     public $shopId;
+
+    /**
+     * Explicit target version to register once the migration succeeds.
+     *
+     * Sourced from the upgrade script (always-fresh code) so we do not rely on the
+     * possibly-stale \Ps_accounts::VERSION const during a zip upgrade. Null falls back
+     * to the const downstream (BC).
+     *
+     * @var string|null
+     */
+    public $version;
 
     /**
      * @param int|null $shopId

--- a/src/Account/CommandHandler/MigrateOrCreateIdentitiesV8Handler.php
+++ b/src/Account/CommandHandler/MigrateOrCreateIdentitiesV8Handler.php
@@ -40,6 +40,7 @@ class MigrateOrCreateIdentitiesV8Handler extends MultiShopHandler
                     (new MigrateOrCreateIdentityV8Command($multiShopId))
                         ->withOrigin($command->origin)
                         ->withSource($command->source)
+                        ->withVersion($command->version)
                 );
             } catch (Exception $e) {
                 Logger::getInstance()->error($e->getMessage());

--- a/src/Account/CommandHandler/MigrateOrCreateIdentityV8Handler.php
+++ b/src/Account/CommandHandler/MigrateOrCreateIdentityV8Handler.php
@@ -131,7 +131,7 @@ class MigrateOrCreateIdentityV8Handler
 
         // FIXME: shouldn't this condition be a specific flag
         if ($notIdentified || $migratedToV8) {
-            $this->registerLatestVersion();
+            $this->registerLatestVersion($command->version);
             $this->createOrVerifyIdentity($command);
 
             return;
@@ -161,10 +161,10 @@ class MigrateOrCreateIdentityV8Handler
 
             $this->clearTokens();
             $this->statusManager->invalidateCache();
-            $this->registerLatestVersion();
+            $this->registerLatestVersion($command->version);
         } catch (StoreLegacyNotFoundException $e) {
             if ($command->origin !== AccountsService::ORIGIN_ADVANCED_SETTINGS) {
-                $this->registerLatestVersion();
+                $this->registerLatestVersion($command->version);
                 $this->cleanupIdentity();
                 $this->createOrVerifyIdentity($command);
 
@@ -265,10 +265,24 @@ class MigrateOrCreateIdentityV8Handler
     }
 
     /**
+     * Register the version reached by this migration.
+     *
+     * Prefer the explicit $version threaded from the upgrade script (fresh code) over
+     * the \Ps_accounts::VERSION const, which is stale on PS9 zip upgrades (the old main
+     * class stays resident in memory). Null keeps the legacy const-based behaviour.
+     *
+     * @param string|null $version
+     *
      * @return void
      */
-    private function registerLatestVersion()
+    private function registerLatestVersion($version = null)
     {
+        if ($version) {
+            $this->upgradeService->setVersion($version);
+
+            return;
+        }
+
         $this->upgradeService->setVersion();
     }
 }

--- a/tests/src/Unit/Account/CommandHandler/MigrateOrCreateIdentityV8HandlerTest.php
+++ b/tests/src/Unit/Account/CommandHandler/MigrateOrCreateIdentityV8HandlerTest.php
@@ -7,6 +7,7 @@ use PrestaShop\Module\PsAccounts\Account\Command\MigrateOrCreateIdentityV8Comman
 use PrestaShop\Module\PsAccounts\Account\CommandHandler\MigrateOrCreateIdentityV8Handler;
 use PrestaShop\Module\PsAccounts\Account\ProofManager;
 use PrestaShop\Module\PsAccounts\Account\StatusManager;
+use PrestaShop\Module\PsAccounts\Cqrs\CommandBus;
 use PrestaShop\Module\PsAccounts\Http\Client\Curl\Client;
 use PrestaShop\Module\PsAccounts\Http\Client\Request;
 use PrestaShop\Module\PsAccounts\Http\Client\Response;
@@ -509,6 +510,44 @@ JSON;
         $this->assertEquals($newCloudShopId, $this->statusManager->getCloudShopId());
 
         // FIXME: test something relevant
+    }
+
+    /**
+     * Bug 2 (PS9 zip upgrade): the version registered in PS_ACCOUNTS_LAST_UPGRADE must come from the
+     * explicit version threaded by the upgrade script, NOT from \Ps_accounts::VERSION (which is stale
+     * in-memory during a PS9 zip upgrade). Here the threaded version differs from the const, and we
+     * assert the threaded one wins.
+     *
+     * @test
+     */
+    public function itShouldRegisterThreadedVersionRatherThanTheConst()
+    {
+        // already-v8 + identified shop -> takes the registerLatestVersion() branch (the 8.0.x -> 8.0.x case)
+        $this->upgradeService->setVersion('8.0.13');
+        $this->configurationRepository->updateShopUuid($this->faker->uuid);
+
+        $threadedVersion = '9.9.9';
+        $this->assertNotEquals($threadedVersion, \Ps_accounts::VERSION);
+
+        // stub the downstream createOrVerifyIdentity dispatch so the test stays focused on version registration
+        $commandBus = $this->createMock(CommandBus::class);
+
+        $handler = new MigrateOrCreateIdentityV8Handler(
+            $this->accountsService,
+            $this->oAuth2Service,
+            $this->shopProvider,
+            $this->statusManager,
+            $this->proofManager,
+            $this->configurationRepository,
+            $commandBus,
+            $this->upgradeService
+        );
+
+        $handler->handle(
+            (new MigrateOrCreateIdentityV8Command($this->shopId))->withVersion($threadedVersion)
+        );
+
+        $this->assertEquals($threadedVersion, $this->upgradeService->getRegisteredVersion());
     }
 
     /**

--- a/upgrade/helpers.php
+++ b/upgrade/helpers.php
@@ -9,13 +9,16 @@ use PrestaShop\Module\PsAccounts\Service\Accounts\AccountsService;
 
 /**
  * @param Ps_accounts $module
+ * @param string|null $version target version to register once migrated. Passed by the
+ *                             upgrade script (always-fresh code) to avoid the stale
+ *                             \Ps_accounts::VERSION const on PS9 zip upgrades. Null = const fallback.
  *
  * @return void
  *
  * @throws Exception
  * @throws Throwable
  */
-function migrate_or_create_identities_v8($module)
+function migrate_or_create_identities_v8($module, $version = null)
 {
     try {
         /** @var CommandBus $commandBus */
@@ -24,6 +27,7 @@ function migrate_or_create_identities_v8($module)
         $commandBus->handle(
             (new MigrateOrCreateIdentitiesV8Command())
                 ->withOrigin(AccountsService::ORIGIN_UPGRADE)
+                ->withVersion($version)
         );
     } catch (\Exception $e) {
         Logger::getInstance()->error('error during upgrade : ' . $e);

--- a/upgrade/upgrade-8.0.15.php
+++ b/upgrade/upgrade-8.0.15.php
@@ -14,7 +14,7 @@ function upgrade_module_8_0_15($module)
 {
     require_once __DIR__ . '/helpers.php';
 
-    migrate_or_create_identities_v8($module);
+    migrate_or_create_identities_v8($module, '8.0.15');
 
     /** @var ConfigurationRepository $configurationRepository */
     $configurationRepository = $module->getService(ConfigurationRepository::class);


### PR DESCRIPTION
## Context

Ticket: **[ACC-3389](https://prestashop-jira.atlassian.net/browse/ACC-3389)** (sprint ACCOUNT S23-25)

On PrestaShop **9** BO **zip** upgrades, the module's `PS_ACCOUNTS_LAST_UPGRADE` config key was not bumped (forcing the *"Action required: reset your PS Account module"* banner) even though the migration ran and `ps_module.version` reached the target. Reproduces on 7.2.2→8.0.15 and 8.0.13→8.0.15; **does not** affect PS8.

## Root cause

`registerLatestVersion()` called `UpgradeService::setVersion()` with no argument, defaulting to the `\Ps_accounts::VERSION` **const**. On PS9 the module version is read by *static-parsing* the file (the class is never re-instantiated), so the old `Ps_accounts` class stays resident in memory and the const is **stale** — exactly the hazard already documented at `ps_accounts.php:98-99`. PS8 instantiates the module, so the const is correct there. The stale value was written over the existing one — a silent no-op (the migration itself ran fine).

## Fix

Thread the explicit target version from the upgrade script (always-fresh code, re-`include`d by core every run) down through the migrate commands to `setVersion()`. A `null` version keeps the previous const-based behaviour (full BC).

- `version` property + `@method withVersion/getVersion` on both `MigrateOrCreate(Identity|Identities)V8Command`
- `helpers.php::migrate_or_create_identities_v8()` accepts `$version`
- `upgrade-8.0.15.php` passes the literal `'8.0.15'`
- plural handler forwards `$command->version`; `registerLatestVersion($version)` uses it, falling back to the const when `null`
- unit test asserting the threaded version wins over the const

## Validation

- `php-cs-fixer` ✅ · `phpstan` ✅ · full unit suite **169 tests, 0 failures** (18 pre-existing skips)
- New test passes; existing handler tests (the `null`→const path) still pass → **BC preserved**
- **End-to-end confirmed on a live PS 9.1 instance**: `PS_ACCOUNTS_LAST_UPGRADE` reaches `8.0.15`, no reset banner

## Scope

Fixes the consistent v8→v8 case. The **intermittent** `ServiceNotFound` autoload hijack on the 7.2.2→8.0.15 chain is out of scope; its notification/manual-reset recovery is intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACC-3389]: https://prestashop-jira.atlassian.net/browse/ACC-3389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ