### PR TITLE
[ACC-3420] fix(oauth2): support Cookie SameSite=Strict via same-site bounce

### DIFF
--- a/_dev/package.json
+++ b/_dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ps_accounts",
-  "version": "8.0.15",
+  "version": "8.0.16",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/config.local.php
+++ b/config.local.php
@@ -52,5 +52,5 @@ return [
     'ps_accounts.token_expiration_leeway' => 60,
 
     'ps_accounts.testimonials_url' => 'https://assets.prestashop3.com/dst/accounts/assets/testimonials.json',
-    'ps_accounts.log_level' => 'DEBUG',
+    'ps_accounts.log_level' => 'ERROR',
 ];

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_accounts</name>
     <displayName><![CDATA[PrestaShop Account]]></displayName>
-    <version><![CDATA[8.0.15]]></version>
+    <version><![CDATA[8.0.16]]></version>
     <description><![CDATA[Link your store to your PrestaShop account to activate and manage your subscriptions in your back office. Do not uninstall this module if you have a current subscription.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[administration]]></tab>

--- a/controllers/admin/AdminOAuth2PsAccountsController.php
+++ b/controllers/admin/AdminOAuth2PsAccountsController.php
@@ -283,7 +283,7 @@ class AdminOAuth2PsAccountsController extends \ModuleAdminController
     /**
      * @param string $url
      *
-     * @return void
+     * @return mixed
      */
     protected function renderSameSiteBounce($url)
     {

--- a/controllers/admin/AdminOAuth2PsAccountsController.php
+++ b/controllers/admin/AdminOAuth2PsAccountsController.php
@@ -291,13 +291,22 @@ class AdminOAuth2PsAccountsController extends \ModuleAdminController
      */
     protected function renderSameSiteBounce($url)
     {
-        // On the cross-site (SameSite=Strict) return, the admin/session cookie was
-        // not sent, so the first session access started an empty session and PHP
-        // already queued a Set-Cookie with a brand-new id. Left in place, that
-        // header would overwrite the browser's original cookie, and the same-site
-        // replay would still land on an empty session. The bounce is a dead-end
-        // page that must set no cookie at all: drop every queued Set-Cookie so the
-        // browser keeps its original cookies and re-sends them on the replay.
+        // The bounce is a dead-end page that must set NO cookie: the browser has to
+        // keep its original cookies and re-send them on the same-site replay.
+        //
+        // On the cross-site (SameSite=Strict) return the admin cookie isn't sent, so
+        // PrestaShop builds an anonymous Cookie. Its write() runs on __destruct (i.e.
+        // during exit, after header_remove() below, and with output buffering on
+        // headers_sent() is still false) and would re-emit an anonymous admin cookie
+        // that overwrites the real one in the browser -> employee logged out on the
+        // next page. disallowWriting() neutralizes that destructor write.
+        $cookie = \Context::getContext()->cookie;
+        if (method_exists($cookie, 'disallowWriting')) {
+            $cookie->disallowWriting();
+        }
+
+        // Also drop any Set-Cookie already queued (e.g. the empty Symfony session id
+        // minted by the first session access) so it can't clobber the session cookie.
         if (!headers_sent()) {
             header_remove('Set-Cookie');
         }

--- a/controllers/admin/AdminOAuth2PsAccountsController.php
+++ b/controllers/admin/AdminOAuth2PsAccountsController.php
@@ -281,6 +281,17 @@ class AdminOAuth2PsAccountsController extends \ModuleAdminController
     }
 
     /**
+     * @param string $url
+     *
+     * @return void
+     */
+    protected function renderSameSiteBounce($url)
+    {
+        echo $this->buildBounceHtml($url);
+        exit;
+    }
+
+    /**
      * @param bool $forceSignup
      *
      * @return void

--- a/controllers/admin/AdminOAuth2PsAccountsController.php
+++ b/controllers/admin/AdminOAuth2PsAccountsController.php
@@ -28,7 +28,6 @@ use PrestaShop\Module\PsAccounts\AccountLogin\OAuth2LoginTrait;
 use PrestaShop\Module\PsAccounts\AccountLogin\OAuth2Session;
 use PrestaShop\Module\PsAccounts\Cqrs\CommandBus;
 use PrestaShop\Module\PsAccounts\Log\Logger;
-use PrestaShop\Module\PsAccounts\Polyfill\ConfigurationStorageSession;
 use PrestaShop\Module\PsAccounts\Polyfill\Traits\AdminController\IsAnonymousAllowed;
 use PrestaShop\Module\PsAccounts\Service\AnalyticsService;
 use PrestaShop\Module\PsAccounts\Service\OAuth2\OAuth2Service;
@@ -210,7 +209,10 @@ class AdminOAuth2PsAccountsController extends \ModuleAdminController
     {
         if ($this->getOAuthAction() === 'identifyPointOfContact') {
             $forceSignup = $this->getForceSignup();
-            $this->getSession()->clear();
+            // Clear only our transient OAuth keys, NOT the whole session: on PS 1.7+
+            // getSession() is the core BO session and a full clear() would log the
+            // employee out on the next page.
+            $this->clearOAuth2SessionState();
             $this->closePopup($forceSignup);
         }
         $returnTo = $this->getReturnTo() ?: 'AdminDashboard';
@@ -248,11 +250,13 @@ class AdminOAuth2PsAccountsController extends \ModuleAdminController
      */
     protected function getSession()
     {
-        if (\Context::getContext()->employee->id) {
-            // FIXME: fallback only for setPointOfContact
-            return $this->module->getService(ConfigurationStorageSession::class);
-        }
-
+        // module->getSession() already returns the ConfigurationStorageSession
+        // fallback on PS 1.6 (no core Symfony session) and the core session on
+        // PS 1.7+. We use it for both login AND point of contact so the same-site
+        // bounce can recover a session lost under Cookie SameSite=Strict. The
+        // point-of-contact flow no longer needs a dedicated store: redirectAfterLogin()
+        // clears only the transient OAuth keys (clearOAuth2SessionState()) instead
+        // of the whole session, so the logged-in employee is kept signed in.
         return $this->module->getSession();
     }
 

--- a/controllers/admin/AdminOAuth2PsAccountsController.php
+++ b/controllers/admin/AdminOAuth2PsAccountsController.php
@@ -287,6 +287,17 @@ class AdminOAuth2PsAccountsController extends \ModuleAdminController
      */
     protected function renderSameSiteBounce($url)
     {
+        // On the cross-site (SameSite=Strict) return, the admin/session cookie was
+        // not sent, so the first session access started an empty session and PHP
+        // already queued a Set-Cookie with a brand-new id. Left in place, that
+        // header would overwrite the browser's original cookie, and the same-site
+        // replay would still land on an empty session. The bounce is a dead-end
+        // page that must set no cookie at all: drop every queued Set-Cookie so the
+        // browser keeps its original cookies and re-sends them on the replay.
+        if (!headers_sent()) {
+            header_remove('Set-Cookie');
+        }
+
         echo $this->buildBounceHtml($url);
         exit;
     }

--- a/doc/oauth2-samesite-strict.md
+++ b/doc/oauth2-samesite-strict.md
@@ -60,14 +60,25 @@ proprement sur `Invalid state`, sans boucler. **Au plus un hop supplémentaire.*
 
 ### Préservation du cookie (Symfony, PS < 9)
 
-Sur Symfony (PS 1.7/8), `Ps_accounts::getSession()` renvoie la **session cœur** (service
-`session`). Au premier accès (`getShopId()`, puis `has('oauth2state')`), `session_start()` est
-appelé : sur le retour cross-site sans cookie, il **crée une session vide et émet aussitôt un
-`Set-Cookie`** (nouvel id) qui **écraserait le cookie d'origine** → le rebond same-site repartirait
-alors avec un cookie vide. Pour l'éviter, `AdminOAuth2PsAccountsController::renderSameSiteBounce()`
-**purge tout `Set-Cookie` en attente** (`header_remove('Set-Cookie')`) avant d'émettre la page de
-rebond : c'est une page cul-de-sac qui ne doit poser aucun cookie, donc le navigateur conserve ses
-cookies d'origine et les renvoie au replay. PS 9 (réponse Symfony) n'est pas concerné.
+Le rebond est une page **cul-de-sac qui ne doit poser aucun cookie** : le navigateur doit conserver
+ses cookies d'origine et les renvoyer au replay same-site. Sur le retour cross-site sans cookie,
+deux écritures de cookie parasites doivent être neutralisées dans
+`AdminOAuth2PsAccountsController::renderSameSiteBounce()` :
+
+1. **Cookie de session Symfony** — `Ps_accounts::getSession()` renvoie la session cœur ; le premier
+   accès (`getShopId()`, puis `has('oauth2state')`) déclenche `session_start()`, qui crée une
+   session vide et émet aussitôt un `Set-Cookie` (nouvel id). On le retire avec
+   `header_remove('Set-Cookie')`.
+2. **Cookie admin (employé)** — le cookie employé n'étant pas envoyé, PrestaShop construit un
+   `Cookie` **anonyme** dont le `write()` s'exécute sur `__destruct` (donc pendant `exit`, **après**
+   `header_remove`, et avec l'output buffering du BO `headers_sent()` est encore faux → le
+   `setcookie()` réussit) : il **réémet un cookie admin anonyme qui écrase le vrai** → employé
+   déconnecté à la page suivante. On bloque cette écriture avec
+   `Context::cookie->disallowWriting()` (méthode cœur, gardée par `method_exists`).
+
+Sans (2), le **login** s'en remettait (il réécrit un cookie employé neuf via `$cookie->write()`),
+mais le **point de contact** restait déconnecté (il ne réécrit jamais le cookie employé). PS 9
+(réponse Symfony, pas d'`exit`) n'est pas concerné.
 
 ### Sécurité
 
@@ -84,7 +95,7 @@ cookies d'origine et les renvoie au replay. PS 9 (réponse Symfony) n'est pas co
 | Fichier | Rôle |
 |---------|------|
 | `src/AccountLogin/OAuth2LoginTrait.php` | Détection (`oauth2Login()`), `hasAlreadyBounced()`, `buildBounceUrl()`, `buildBounceHtml()`, abstrait `renderSameSiteBounce()` |
-| `controllers/admin/AdminOAuth2PsAccountsController.php` (PS < 9) | `renderSameSiteBounce()` → `header_remove('Set-Cookie')` + `echo … ; exit;` |
+| `controllers/admin/AdminOAuth2PsAccountsController.php` (PS < 9) | `renderSameSiteBounce()` → `disallowWriting()` + `header_remove('Set-Cookie')` + `echo … ; exit;` |
 | `src/Controller/Admin/OAuth2Controller.php` (PS 9+) | `renderSameSiteBounce()` → `Response` |
 
 ## État par flux et par version (`Strict`)

--- a/doc/oauth2-samesite-strict.md
+++ b/doc/oauth2-samesite-strict.md
@@ -87,58 +87,56 @@ cookies d'origine et les renvoie au replay. PS 9 (réponse Symfony) n'est pas co
 | `controllers/admin/AdminOAuth2PsAccountsController.php` (PS < 9) | `renderSameSiteBounce()` → `header_remove('Set-Cookie')` + `echo … ; exit;` |
 | `src/Controller/Admin/OAuth2Controller.php` (PS 9+) | `renderSameSiteBounce()` → `Response` |
 
-## État par flux et par version (`Strict`, validé E2E)
+## État par flux et par version (`Strict`)
 
 | Flux | PS 9 | PS 8 / 1.7 | PS 1.6 |
 |------|------|------------|--------|
 | **Login BO** | ✅ | ✅ (rebond + purge `Set-Cookie`) | à valider |
-| **Point de contact** | ✅ | ❌ **non résolu** (voir ci-dessous) | à valider |
+| **Point de contact** | ✅ | ✅ (session cœur + clear ciblé) — **à valider en E2E** | à valider |
 
-- **Login** : OK sur PS 9, 8 et 1.7. L'état OAuth vit dans la session cœur ; le rebond + la purge
-  du `Set-Cookie` préservent le cookie de session, qui repart au replay same-site.
-- **Point de contact** : OK sur PS 9 ; **toujours KO sur PS 8 / 1.7** malgré le rebond — à cause de
-  la fallback `ConfigurationStorageSession` (cf. section suivante).
+- **Login** : l'état OAuth vit dans la session cœur ; le rebond + la purge du `Set-Cookie`
+  préservent le cookie de session, qui repart au replay same-site.
+- **Point de contact** : voir la section suivante.
 
-## Limitation connue : point de contact sur PS 8 / 1.7
+## Point de contact : session cœur + clear ciblé (PS 1.7+)
 
-### Pourquoi le rebond ne suffit pas
+### Le problème historique
 
-En mode **connecté**, `AdminOAuth2PsAccountsController::getSession()` renvoie
-`ConfigurationStorageSession` (store DB) **dès que `Context::employee->id` est défini** — et non la
-session cœur. Cette fallback est **forcée pour le point de contact, pas seulement en PS 1.6**.
+`AdminOAuth2PsAccountsController::getSession()` renvoyait `ConfigurationStorageSession` (store DB,
+indexé par `id_fallback_session` porté par le cookie employé) **dès que `Context::employee->id`
+était défini** — sur **toutes** les versions, pas seulement PS 1.6. Cette fallback était la
+**raison d'être** du bon fonctionnement du point de contact malgré le `clear()` final :
+`redirectAfterLogin()` appelait `$this->getSession()->clear()` en fin de flux ; avec la session
+cœur, ce `clear()` aurait **vidé la session BO de l'employé** → déconnexion à la page suivante. La
+fallback isolait donc l'état OAuth dans un store séparé pour protéger la session BO.
 
-Au retour cross-site `Strict`, le cookie employé n'est pas envoyé → `employee->id == 0` →
-`getSession()` retombe sur la session cœur (pas sur `ConfigurationStorageSession`) → rebond. Même
-avec la purge du `Set-Cookie`, la **récupération du point de contact n'aboutit pas** sur PS 8 / 1.7
-(mécanisme exact encore à confirmer ; l'état transitoire est indexé par `id_fallback_session`, porté
-par le cookie employé — l'interaction avec le retour cross-site reste à élucider).
+Mais sous `Strict`, cette fallback **empêche le rebond** : au retour cross-site le cookie employé
+n'est pas envoyé → `employee->id == 0` → `getSession()` ne retombe pas sur le store DB, et la
+récupération n'aboutit pas (le point de contact restait KO sur PS 8 / 1.7).
 
-### Le compromis (et pourquoi on ne peut pas juste « ignorer la fallback »)
+### La solution
 
-Si l'on **force la session cœur** pour le point de contact (au lieu de `ConfigurationStorageSession`),
-le rebond **récupère bien** le point de contact sur PS 8 / 1.7 — **mais le marchand est déconnecté
-à la page suivante** (le set point de contact passe, puis on retombe sur le login).
+Découpler les deux responsabilités :
 
-Cause : `redirectAfterLogin()` appelle `$this->getSession()->clear()` en fin de point de contact
-(`controllers/admin/AdminOAuth2PsAccountsController.php:213`). Avec la session cœur, ce `clear()`
-**vide la session BO de l'employé** → déconnexion. C'est précisément **la raison d'être de la
-fallback `ConfigurationStorageSession`** : isoler l'état OAuth transitoire dans un store DB séparé
-pour que le `clear()` final ne détruise pas la session BO (`getSession()` L249-257 + commentaire
-`// FIXME: fallback only for setPointOfContact` L252).
+1. **Clear ciblé** — `redirectAfterLogin()` appelle désormais `clearOAuth2SessionState()`
+   (`OAuth2LoginTrait`) au lieu de `getSession()->clear()`. Cette méthode ne retire **que** les clés
+   transitoires OAuth (`oauth2state`, `oauth2pkceCode`, `oauth2action`, `source`, `shopId`,
+   `forceSignup`, `return_to`) et laisse le reste de la session intact → la session BO survit, même
+   quand `getSession()` est la session cœur.
+2. **Fallback re-scopée à PS 1.6** — `getSession()` renvoie simplement `module->getSession()`, qui
+   rend `ConfigurationStorageSession` **uniquement sur PS 1.6** (pas de conteneur cœur) et la session
+   cœur sur PS 1.7+. Le point de contact utilise donc la **même** session que le login sur PS 1.7+,
+   ce qui rend le **rebond opérant** pour les deux flux. PS 1.6 n'est pas concerné par SameSite=Strict.
 
-### Conséquence
+Effet de bord corrigé au passage : `ConfigurationStorageSession::remove()` écrivait dans une clé de
+configuration nommée d'après l'attribut au lieu de la ligne de session (`getConfigurationName()`) —
+corrigé pour que le clear ciblé fonctionne aussi sur PS 1.6.
 
-Tant que cette tension n'est pas levée, sur PS 8 / 1.7 :
-- soit on garde la fallback → BO préservé mais **point de contact KO en `Strict`** ;
-- soit on l'ignore → point de contact OK en `Strict` mais **régression d'auth BO** (déconnexion).
-
-Pistes pour une vraie solution (non implémentées) : ne `clear()` que l'état OAuth transitoire sans
-toucher la session BO ; ou stocker l'état transitoire dans un store indépendant du cookie employé,
-réhydratable au replay sans dépendre de `employee->id`.
+> PS 9 (`OAuth2Controller`) ne fait pas de `clear()` final et n'utilise pas la fallback : inchangé.
 
 ## Recommandation marchand
 
-`Lax` reste le réglage **recommandé** (et le défaut PrestaShop). En `Strict` : le **login** est
-désormais supporté (rebond same-site, redirection invisible) ; le **point de contact** n'est **pas
-encore supporté sur PS 8 / 1.7** (OK sur PS 9). À documenter côté support tant que la limitation
-n'est pas levée.
+`Lax` reste le réglage **recommandé** (et le défaut PrestaShop). En `Strict`, **login** et
+**point de contact** sont désormais supportés via le rebond same-site (redirection invisible). À
+**valider en E2E** sur PS 8 / 1.7 (les deux flux, point de contact dans la popup) avant de
+communiquer le support de `Strict`.

--- a/doc/oauth2-samesite-strict.md
+++ b/doc/oauth2-samesite-strict.md
@@ -1,0 +1,100 @@
+# OAuth2 & le réglage `Cookie SameSite` de PrestaShop
+
+## Symptôme
+
+Quand un marchand règle **Paramètres avancés > Administration > Paramètres généraux >
+Cookie SameSite = `Strict`** (configuration `PS_COOKIE_SAMESITE`), les flux OAuth2 du module
+échouent :
+
+- **Login BO** via PrestaShop Account.
+- **Identification du point de contact** (`action=identifyPointOfContact`).
+- Plus généralement tout flux qui repart d'auth-hydra vers le back-office.
+
+En `Lax` (valeur **par défaut** de PrestaShop) ou `None` (+ HTTPS/`Secure`), tout fonctionne.
+
+## Cause
+
+Le flux OAuth2 (authorization code + PKCE) stocke `oauth2state` et `oauth2pkceCode` **dans la
+session BO** avant de rediriger vers auth-hydra
+(`src/AccountLogin/OAuth2LoginTrait.php`, `oauth2Redirect()`).
+
+Au retour, auth-hydra renvoie un `302` vers notre callback (`ps_accounts_oauth2` /
+`AdminOAuth2PsAccountsController`). C'est une **navigation top-level cross-site** :
+
+| `PS_COOKIE_SAMESITE` | Cookie admin envoyé sur ce retour ? | Résultat |
+|----------------------|-------------------------------------|----------|
+| `Lax` (défaut)       | Oui (navigation GET top-level)      | OK       |
+| `None` (+ Secure)    | Oui                                 | OK       |
+| `Strict`             | **Non**                             | Session vide → flux cassé |
+
+Avec `Strict`, le navigateur **retient** le cookie de session. Le callback s'exécute donc sur une
+session **vide** : `oauth2state`/`oauth2pkceCode` ont disparu. Sans le `code_verifier`, l'échange
+de token renvoyait un `invalid_grant` opaque ; pour le login/point de contact, le cookie employé
+n'est pas non plus renvoyé, donc le callback s'exécute sans employé.
+
+On ne peut pas réparer côté serveur une requête entrante qui ne porte pas le cookie — **sauf** en
+la rejouant en *same-site*, contexte où `Strict` autorise l'envoi du cookie.
+
+## Correctif : rebond same-site
+
+Lorsque le callback détecte une session perdue (`!$session->has('oauth2state')` avec un `code` et
+un `state` présents dans l'URL), au lieu d'échouer, le module sert une petite page HTML
+**same-origin** qui re-navigue immédiatement (`window.location.replace`) vers **la même URL** de
+callback — paramètres `code`/`state` préservés, plus un marqueur one-shot `__ps_oauth_retry=1`.
+
+Cette seconde navigation est **same-site** → le navigateur envoie le cookie `Strict` → la session
+est restaurée → le flux se déroule normalement.
+
+```
+auth-hydra ──302──▶ callback (cross-site, cookie Strict NON envoyé → session vide)
+                        │
+                        ▼ page HTML same-origin : location.replace(url + &__ps_oauth_retry=1)
+                    callback (SAME-SITE, cookie Strict envoyé → session restaurée) ──▶ flux OK
+```
+
+### Garde anti-boucle
+
+Si le marqueur `__ps_oauth_retry=1` est **déjà** présent et que la session est **toujours** vide,
+c'est une perte de session réelle (session expirée, cookies désactivés…) : le module échoue
+proprement sur `Invalid state`, sans boucler. **Au plus un hop supplémentaire.**
+
+### Sécurité
+
+- Le `code` n'est **jamais** échangé sans un `oauth2state` de session correspondant.
+- Le contrôle CSRF (`$state !== $session->get('oauth2state')`) reste actif après restauration.
+- L'URL de rebond est échappée (`json_encode` côté JS, `htmlspecialchars(..., ENT_QUOTES)` côté
+  `<noscript>` meta-refresh) car elle reflète des paramètres d'URL.
+- Le déclenchement est **piloté par le symptôme** (session absente + `code`/`state` présents), pas
+  par la lecture de `PS_COOKIE_SAMESITE` — ce qui couvre aussi d'autres causes de cookie non
+  renvoyé.
+
+## Implémentation
+
+| Fichier | Rôle |
+|---------|------|
+| `src/AccountLogin/OAuth2LoginTrait.php` | Détection (`oauth2Login()`), `hasAlreadyBounced()`, `buildBounceUrl()`, `buildBounceHtml()`, abstrait `renderSameSiteBounce()` |
+| `controllers/admin/AdminOAuth2PsAccountsController.php` (PS < 9) | `renderSameSiteBounce()` → `echo … ; exit;` |
+| `src/Controller/Admin/OAuth2Controller.php` (PS 9+) | `renderSameSiteBounce()` → `Response` |
+
+## Validation & point d'attention
+
+Le correctif repose sur une hypothèse : **le cookie de session d'origine survit dans le
+navigateur et est renvoyé sur le rebond same-site.** Sur Symfony, le callback lit la session
+(`getShopId()`, `has('oauth2state')`) **avant** de décider de rebondir, ce qui démarre une session
+vide ; le risque théorique était qu'un `Set-Cookie` parasite écrase le cookie d'origine et fasse
+échouer le rebond.
+
+➡️ **Validé en E2E sur PrestaShop 9 + `Strict` : le flux aboutit.** PrestaShop ne réémet pas de
+`Set-Cookie` destructeur sur la session vide lue au premier passage, donc le cookie d'origine est
+bien renvoyé sur le rebond.
+
+Lors de la revue, sanity-check rapide possible sur les autres versions (legacy PS 1.6 a priori
+sûr : pas de `$cookie->write()` avant `exit`). Si un jour un écrasement apparaissait sur une
+version, la parade serait de rebondir **avant** de toucher la session (PS9 :
+`$request->hasPreviousSession()`).
+
+## Recommandation marchand
+
+`Lax` reste le réglage **recommandé** (et le défaut PrestaShop). `Strict` est désormais
+**supporté** grâce au rebond, au prix d'une redirection supplémentaire invisible pour
+l'utilisateur.

--- a/doc/oauth2-samesite-strict.md
+++ b/doc/oauth2-samesite-strict.md
@@ -58,6 +58,17 @@ Si le marqueur `__ps_oauth_retry=1` est **déjà** présent et que la session es
 c'est une perte de session réelle (session expirée, cookies désactivés…) : le module échoue
 proprement sur `Invalid state`, sans boucler. **Au plus un hop supplémentaire.**
 
+### Préservation du cookie (Symfony, PS < 9)
+
+Sur Symfony (PS 1.7/8), `Ps_accounts::getSession()` renvoie la **session cœur** (service
+`session`). Au premier accès (`getShopId()`, puis `has('oauth2state')`), `session_start()` est
+appelé : sur le retour cross-site sans cookie, il **crée une session vide et émet aussitôt un
+`Set-Cookie`** (nouvel id) qui **écraserait le cookie d'origine** → le rebond same-site repartirait
+alors avec un cookie vide. Pour l'éviter, `AdminOAuth2PsAccountsController::renderSameSiteBounce()`
+**purge tout `Set-Cookie` en attente** (`header_remove('Set-Cookie')`) avant d'émettre la page de
+rebond : c'est une page cul-de-sac qui ne doit poser aucun cookie, donc le navigateur conserve ses
+cookies d'origine et les renvoie au replay. PS 9 (réponse Symfony) n'est pas concerné.
+
 ### Sécurité
 
 - Le `code` n'est **jamais** échangé sans un `oauth2state` de session correspondant.
@@ -73,28 +84,61 @@ proprement sur `Invalid state`, sans boucler. **Au plus un hop supplémentaire.*
 | Fichier | Rôle |
 |---------|------|
 | `src/AccountLogin/OAuth2LoginTrait.php` | Détection (`oauth2Login()`), `hasAlreadyBounced()`, `buildBounceUrl()`, `buildBounceHtml()`, abstrait `renderSameSiteBounce()` |
-| `controllers/admin/AdminOAuth2PsAccountsController.php` (PS < 9) | `renderSameSiteBounce()` → `echo … ; exit;` |
+| `controllers/admin/AdminOAuth2PsAccountsController.php` (PS < 9) | `renderSameSiteBounce()` → `header_remove('Set-Cookie')` + `echo … ; exit;` |
 | `src/Controller/Admin/OAuth2Controller.php` (PS 9+) | `renderSameSiteBounce()` → `Response` |
 
-## Validation & point d'attention
+## État par flux et par version (`Strict`, validé E2E)
 
-Le correctif repose sur une hypothèse : **le cookie de session d'origine survit dans le
-navigateur et est renvoyé sur le rebond same-site.** Sur Symfony, le callback lit la session
-(`getShopId()`, `has('oauth2state')`) **avant** de décider de rebondir, ce qui démarre une session
-vide ; le risque théorique était qu'un `Set-Cookie` parasite écrase le cookie d'origine et fasse
-échouer le rebond.
+| Flux | PS 9 | PS 8 / 1.7 | PS 1.6 |
+|------|------|------------|--------|
+| **Login BO** | ✅ | ✅ (rebond + purge `Set-Cookie`) | à valider |
+| **Point de contact** | ✅ | ❌ **non résolu** (voir ci-dessous) | à valider |
 
-➡️ **Validé en E2E sur PrestaShop 9 + `Strict` : le flux aboutit.** PrestaShop ne réémet pas de
-`Set-Cookie` destructeur sur la session vide lue au premier passage, donc le cookie d'origine est
-bien renvoyé sur le rebond.
+- **Login** : OK sur PS 9, 8 et 1.7. L'état OAuth vit dans la session cœur ; le rebond + la purge
+  du `Set-Cookie` préservent le cookie de session, qui repart au replay same-site.
+- **Point de contact** : OK sur PS 9 ; **toujours KO sur PS 8 / 1.7** malgré le rebond — à cause de
+  la fallback `ConfigurationStorageSession` (cf. section suivante).
 
-Lors de la revue, sanity-check rapide possible sur les autres versions (legacy PS 1.6 a priori
-sûr : pas de `$cookie->write()` avant `exit`). Si un jour un écrasement apparaissait sur une
-version, la parade serait de rebondir **avant** de toucher la session (PS9 :
-`$request->hasPreviousSession()`).
+## Limitation connue : point de contact sur PS 8 / 1.7
+
+### Pourquoi le rebond ne suffit pas
+
+En mode **connecté**, `AdminOAuth2PsAccountsController::getSession()` renvoie
+`ConfigurationStorageSession` (store DB) **dès que `Context::employee->id` est défini** — et non la
+session cœur. Cette fallback est **forcée pour le point de contact, pas seulement en PS 1.6**.
+
+Au retour cross-site `Strict`, le cookie employé n'est pas envoyé → `employee->id == 0` →
+`getSession()` retombe sur la session cœur (pas sur `ConfigurationStorageSession`) → rebond. Même
+avec la purge du `Set-Cookie`, la **récupération du point de contact n'aboutit pas** sur PS 8 / 1.7
+(mécanisme exact encore à confirmer ; l'état transitoire est indexé par `id_fallback_session`, porté
+par le cookie employé — l'interaction avec le retour cross-site reste à élucider).
+
+### Le compromis (et pourquoi on ne peut pas juste « ignorer la fallback »)
+
+Si l'on **force la session cœur** pour le point de contact (au lieu de `ConfigurationStorageSession`),
+le rebond **récupère bien** le point de contact sur PS 8 / 1.7 — **mais le marchand est déconnecté
+à la page suivante** (le set point de contact passe, puis on retombe sur le login).
+
+Cause : `redirectAfterLogin()` appelle `$this->getSession()->clear()` en fin de point de contact
+(`controllers/admin/AdminOAuth2PsAccountsController.php:213`). Avec la session cœur, ce `clear()`
+**vide la session BO de l'employé** → déconnexion. C'est précisément **la raison d'être de la
+fallback `ConfigurationStorageSession`** : isoler l'état OAuth transitoire dans un store DB séparé
+pour que le `clear()` final ne détruise pas la session BO (`getSession()` L249-257 + commentaire
+`// FIXME: fallback only for setPointOfContact` L252).
+
+### Conséquence
+
+Tant que cette tension n'est pas levée, sur PS 8 / 1.7 :
+- soit on garde la fallback → BO préservé mais **point de contact KO en `Strict`** ;
+- soit on l'ignore → point de contact OK en `Strict` mais **régression d'auth BO** (déconnexion).
+
+Pistes pour une vraie solution (non implémentées) : ne `clear()` que l'état OAuth transitoire sans
+toucher la session BO ; ou stocker l'état transitoire dans un store indépendant du cookie employé,
+réhydratable au replay sans dépendre de `employee->id`.
 
 ## Recommandation marchand
 
-`Lax` reste le réglage **recommandé** (et le défaut PrestaShop). `Strict` est désormais
-**supporté** grâce au rebond, au prix d'une redirection supplémentaire invisible pour
-l'utilisateur.
+`Lax` reste le réglage **recommandé** (et le défaut PrestaShop). En `Strict` : le **login** est
+désormais supporté (rebond same-site, redirection invisible) ; le **point de contact** n'est **pas
+encore supporté sur PS 8 / 1.7** (OK sur PS 9). À documenter côté support tant que la limitation
+n'est pas levée.

--- a/doc/oauth2-samesite-strict.md
+++ b/doc/oauth2-samesite-strict.md
@@ -102,12 +102,15 @@ mais le **point de contact** restait déconnecté (il ne réécrit jamais le coo
 
 | Flux | PS 9 | PS 8 / 1.7 | PS 1.6 |
 |------|------|------------|--------|
-| **Login BO** | ✅ | ✅ (rebond + purge `Set-Cookie`) | à valider |
-| **Point de contact** | ✅ | ✅ (session cœur + clear ciblé) — **à valider en E2E** | à valider |
+| **Login BO** | ✅ validé E2E | ✅ validé E2E | à valider |
+| **Point de contact** | ✅ validé E2E | ✅ validé E2E | à valider |
 
 - **Login** : l'état OAuth vit dans la session cœur ; le rebond + la purge du `Set-Cookie`
   préservent le cookie de session, qui repart au replay same-site.
-- **Point de contact** : voir la section suivante.
+- **Point de contact** : voir la section suivante (session cœur + clear ciblé + `disallowWriting`).
+- **PS 8 / 1.7** validés E2E (les deux flux, point de contact dans la popup). **PS 1.6** reste à
+  valider (pas de SameSite Strict en pratique sur ces versions ; `getSession()` y rend la
+  `ConfigurationStorageSession` comme avant).
 
 ## Point de contact : session cœur + clear ciblé (PS 1.7+)
 
@@ -148,6 +151,6 @@ corrigé pour que le clear ciblé fonctionne aussi sur PS 1.6.
 ## Recommandation marchand
 
 `Lax` reste le réglage **recommandé** (et le défaut PrestaShop). En `Strict`, **login** et
-**point de contact** sont désormais supportés via le rebond same-site (redirection invisible). À
-**valider en E2E** sur PS 8 / 1.7 (les deux flux, point de contact dans la popup) avant de
-communiquer le support de `Strict`.
+**point de contact** sont désormais supportés via le rebond same-site (redirection invisible),
+**validés E2E sur PS 9, 8 et 1.7**. PS 1.6 reste à confirmer (non concerné par SameSite Strict en
+pratique).

--- a/ps_accounts.php
+++ b/ps_accounts.php
@@ -33,7 +33,7 @@ class Ps_accounts extends Module
 
     // Needed in order to retrieve the module version easier (in api call headers) than instanciate
     // the module each time to get the version
-    const VERSION = '8.0.15';
+    const VERSION = '8.0.16';
 
     /**
      * Admin tabs
@@ -97,7 +97,7 @@ class Ps_accounts extends Module
 
         // We cannot use the const VERSION because the const is not computed by addons marketplace
         // when the zip is uploaded
-        $this->version = '8.0.15';
+        $this->version = '8.0.16';
 
         $this->module_key = 'abf2cd758b4d629b2944d3922ef9db73';
 

--- a/src/AccountLogin/Exception/InvalidOAuth2StateException.php
+++ b/src/AccountLogin/Exception/InvalidOAuth2StateException.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\PsAccounts\AccountLogin\Exception;
+
+/**
+ * Thrown when the OAuth2 callback state is invalid: missing/empty state, a state
+ * that no longer matches the one stored in session (CSRF), or a session lost on
+ * the cross-site return that could not be recovered via a same-site bounce.
+ */
+class InvalidOAuth2StateException extends \Exception
+{
+    /**
+     * @param string $message
+     * @param int $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($message = 'Invalid state', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/AccountLogin/OAuth2LoginTrait.php
+++ b/src/AccountLogin/OAuth2LoginTrait.php
@@ -24,6 +24,7 @@ use Employee;
 use PrestaShop\Module\PsAccounts\AccountLogin\Exception\AccountLoginException;
 use PrestaShop\Module\PsAccounts\AccountLogin\Exception\EmailNotVerifiedException;
 use PrestaShop\Module\PsAccounts\AccountLogin\Exception\EmployeeNotFoundException;
+use PrestaShop\Module\PsAccounts\AccountLogin\Exception\InvalidOAuth2StateException;
 use PrestaShop\Module\PsAccounts\AccountLogin\Exception\Oauth2LoginException;
 use PrestaShop\Module\PsAccounts\Context\ShopContext;
 use PrestaShop\Module\PsAccounts\Entity\EmployeeAccount;
@@ -152,50 +153,92 @@ trait OAuth2LoginTrait
                 $this->setForceSignup($forceSignup);
 
                 $this->oauth2Redirect(Tools::getValue('locale', 'en'), $shopId);
-
-            // No state at all in the callback: nothing to validate against, reject.
-            } elseif (empty($state)) {
-                $session->remove('oauth2state');
-
-                throw new \Exception('Invalid state');
-            // Session lost on the callback: oauth2state (and pkceCode) are gone.
-            // The most common cause is PS_COOKIE_SAMESITE=Strict — the browser
-            // withholds the admin cookie on the cross-site redirect back from
-            // auth-hydra, so the session arrives empty. Re-issuing the very same
-            // callback as a SAME-SITE navigation makes the browser send the
-            // cookie, which restores the session and lets the flow complete.
-            } elseif (!$session->has('oauth2state')) {
-                if (!$this->hasAlreadyBounced()) {
-                    return $this->renderSameSiteBounce($this->buildBounceUrl());
-                }
-                // Already bounced once and the session is still missing: this is
-                // a genuine session loss (expired, cookies disabled, ...), fail clean.
-                throw new \Exception('Invalid state');
-            // Check given state against previously stored one to mitigate CSRF attack
-            } elseif ($state !== $session->get('oauth2state')) {
-                $session->remove('oauth2state');
-
-                throw new \Exception('Invalid state');
             } else {
-                $this->assertValidCode($code);
-
-                try {
-                    $accessToken = $apiClient->getAccessTokenByAuthorizationCode(
-                        $code,
-                        $this->getSession()->get('oauth2pkceCode'),
-                        [],
-                        [],
-                        $shopId
-                    );
-                } catch (OAuth2Exception $e) {
-                    throw new Oauth2LoginException($e->getMessage(), null, $e);
-                }
-
-                if ($this->initUserSession($accessToken)) {
-                    return $this->redirectAfterLogin();
-                }
+                // We have an authorization code: validate the callback state and
+                // exchange it for a token (or recover a lost session via bounce).
+                return $this->handleAuthorizationCode($apiClient, $session, $state, $code, $shopId);
             }
         });
+    }
+
+    /**
+     * Validate the OAuth2 callback state then exchange the authorization code.
+     *
+     * @param OAuth2Service $apiClient
+     * @param SessionInterface $session
+     * @param string $state
+     * @param string $code
+     * @param int|null $shopId
+     *
+     * @return mixed bounce response, post-login redirect, or null
+     *
+     * @throws InvalidOAuth2StateException
+     * @throws Oauth2LoginException
+     * @throws EmailNotVerifiedException
+     * @throws EmployeeNotFoundException
+     */
+    private function handleAuthorizationCode($apiClient, $session, $state, $code, $shopId)
+    {
+        // No state at all in the callback: nothing to validate against, reject.
+        if (empty($state)) {
+            $this->rejectInvalidState($session);
+        }
+
+        // Session lost on the callback: oauth2state (and pkceCode) are gone. The
+        // most common cause is PS_COOKIE_SAMESITE=Strict — the browser withholds
+        // the admin cookie on the cross-site redirect back from auth-hydra, so the
+        // session arrives empty. Re-issuing the very same callback as a SAME-SITE
+        // navigation makes the browser send the cookie and restores the session.
+        if (!$session->has('oauth2state')) {
+            if (!$this->hasAlreadyBounced()) {
+                return $this->renderSameSiteBounce($this->buildBounceUrl());
+            }
+            // Already bounced once and the session is still missing: this is a
+            // genuine session loss (expired, cookies disabled, ...), fail clean.
+            $this->rejectInvalidState($session);
+        }
+
+        // Check given state against previously stored one to mitigate CSRF attack.
+        if ($state !== $session->get('oauth2state')) {
+            $this->rejectInvalidState($session);
+        }
+
+        $this->assertValidCode($code);
+
+        try {
+            $accessToken = $apiClient->getAccessTokenByAuthorizationCode(
+                $code,
+                $session->get('oauth2pkceCode'),
+                [],
+                [],
+                $shopId
+            );
+        } catch (OAuth2Exception $e) {
+            throw new Oauth2LoginException($e->getMessage(), null, $e);
+        }
+
+        if ($this->initUserSession($accessToken)) {
+            return $this->redirectAfterLogin();
+        }
+
+        return null;
+    }
+
+    /**
+     * Drop the stored state and reject the callback. Removing an absent key is a
+     * no-op, so this is safe to call when the session was already lost.
+     *
+     * @param SessionInterface $session
+     *
+     * @return void
+     *
+     * @throws InvalidOAuth2StateException
+     */
+    private function rejectInvalidState($session)
+    {
+        $session->remove('oauth2state');
+
+        throw new InvalidOAuth2StateException();
     }
 
     /**

--- a/src/AccountLogin/OAuth2LoginTrait.php
+++ b/src/AccountLogin/OAuth2LoginTrait.php
@@ -189,7 +189,7 @@ trait OAuth2LoginTrait
         // the admin cookie on the cross-site redirect back from auth-hydra, so the
         // session arrives empty. Re-issuing the very same callback as a SAME-SITE
         // navigation makes the browser send the cookie and restores the session.
-        if (!$session->has('oauth2state')) {
+        if (!$session->has(OAuth2SessionKeys::STATE)) {
             if (!$this->hasAlreadyBounced()) {
                 return $this->renderSameSiteBounce($this->buildBounceUrl());
             }
@@ -199,7 +199,7 @@ trait OAuth2LoginTrait
         }
 
         // Check given state against previously stored one to mitigate CSRF attack.
-        if ($state !== $session->get('oauth2state')) {
+        if ($state !== $session->get(OAuth2SessionKeys::STATE)) {
             $this->rejectInvalidState($session);
         }
 
@@ -208,7 +208,7 @@ trait OAuth2LoginTrait
         try {
             $accessToken = $apiClient->getAccessTokenByAuthorizationCode(
                 $code,
-                $session->get('oauth2pkceCode'),
+                $session->get(OAuth2SessionKeys::PKCE_CODE),
                 [],
                 [],
                 $shopId
@@ -236,7 +236,7 @@ trait OAuth2LoginTrait
      */
     private function rejectInvalidState($session)
     {
-        $session->remove('oauth2state');
+        $session->remove(OAuth2SessionKeys::STATE);
 
         throw new InvalidOAuth2StateException();
     }
@@ -304,8 +304,8 @@ trait OAuth2LoginTrait
         $state = $apiClient->getRandomState();
         $pkceCode = $apiClient->getRandomPkceCode();
 
-        $this->getSession()->set('oauth2state', $state);
-        $this->getSession()->set('oauth2pkceCode', $pkceCode);
+        $this->getSession()->set(OAuth2SessionKeys::STATE, $state);
+        $this->getSession()->set(OAuth2SessionKeys::PKCE_CODE, $pkceCode);
 
         $authorizationUrl = $apiClient->getAuthorizationUri(
             $state,
@@ -373,7 +373,7 @@ trait OAuth2LoginTrait
      */
     private function getReturnToParam()
     {
-        return 'return_to';
+        return OAuth2SessionKeys::RETURN_TO;
     }
 
     /**
@@ -381,7 +381,7 @@ trait OAuth2LoginTrait
      */
     private function getOAuthAction()
     {
-        return $this->getSession()->get('oauth2action');
+        return $this->getSession()->get(OAuth2SessionKeys::ACTION);
     }
 
     /**
@@ -391,7 +391,7 @@ trait OAuth2LoginTrait
      */
     private function setOAuthAction($action)
     {
-        $this->getSession()->set('oauth2action', $action);
+        $this->getSession()->set(OAuth2SessionKeys::ACTION, $action);
     }
 
     /**
@@ -399,7 +399,7 @@ trait OAuth2LoginTrait
      */
     private function getSource()
     {
-        return $this->getSession()->get('source');
+        return $this->getSession()->get(OAuth2SessionKeys::SOURCE);
     }
 
     /**
@@ -409,7 +409,7 @@ trait OAuth2LoginTrait
      */
     private function setSource($source)
     {
-        $this->getSession()->set('source', $source);
+        $this->getSession()->set(OAuth2SessionKeys::SOURCE, $source);
     }
 
     /**
@@ -417,7 +417,7 @@ trait OAuth2LoginTrait
      */
     private function getShopId()
     {
-        return $this->getSession()->get('shopId');
+        return $this->getSession()->get(OAuth2SessionKeys::SHOP_ID);
     }
 
     /**
@@ -427,7 +427,7 @@ trait OAuth2LoginTrait
      */
     private function setShopId($shopId)
     {
-        $this->getSession()->set('shopId', $shopId);
+        $this->getSession()->set(OAuth2SessionKeys::SHOP_ID, $shopId);
     }
 
     /**
@@ -435,7 +435,7 @@ trait OAuth2LoginTrait
      */
     private function getForceSignup()
     {
-        return (bool) $this->getSession()->get('forceSignup', false);
+        return (bool) $this->getSession()->get(OAuth2SessionKeys::FORCE_SIGNUP, false);
     }
 
     /**
@@ -445,7 +445,7 @@ trait OAuth2LoginTrait
      */
     private function setForceSignup($forceSignup)
     {
-        $this->getSession()->set('forceSignup', $forceSignup);
+        $this->getSession()->set(OAuth2SessionKeys::FORCE_SIGNUP, $forceSignup);
     }
 
     /**
@@ -460,13 +460,9 @@ trait OAuth2LoginTrait
     {
         $session = $this->getSession();
 
-        $session->remove('oauth2state');
-        $session->remove('oauth2pkceCode');
-        $session->remove('oauth2action');
-        $session->remove('source');
-        $session->remove('shopId');
-        $session->remove('forceSignup');
-        $session->remove($this->getReturnToParam());
+        foreach (OAuth2SessionKeys::values() as $key) {
+            $session->remove($key);
+        }
     }
 
     /**

--- a/src/AccountLogin/OAuth2LoginTrait.php
+++ b/src/AccountLogin/OAuth2LoginTrait.php
@@ -93,6 +93,18 @@ trait OAuth2LoginTrait
     abstract protected function getSignupUrl();
 
     /**
+     * Output a same-origin HTML page that immediately re-navigates to the given
+     * URL. Used to recover from a lost session on the OAuth2 callback when
+     * PS_COOKIE_SAMESITE=Strict prevents the cookie from being sent on the
+     * cross-site return (see buildBounceUrl()).
+     *
+     * @param string $url
+     *
+     * @return mixed
+     */
+    abstract protected function renderSameSiteBounce($url);
+
+    /**
      * @return mixed
      *
      * @throws EmailNotVerifiedException
@@ -141,9 +153,28 @@ trait OAuth2LoginTrait
 
                 $this->oauth2Redirect(Tools::getValue('locale', 'en'), $shopId);
 
+            // No state at all in the callback: nothing to validate against, reject.
+            } elseif (empty($state)) {
+                $session->remove('oauth2state');
+
+                throw new \Exception('Invalid state');
+
+            // Session lost on the callback: oauth2state (and pkceCode) are gone.
+            // The most common cause is PS_COOKIE_SAMESITE=Strict — the browser
+            // withholds the admin cookie on the cross-site redirect back from
+            // auth-hydra, so the session arrives empty. Re-issuing the very same
+            // callback as a SAME-SITE navigation makes the browser send the
+            // cookie, which restores the session and lets the flow complete.
+            } elseif (!$session->has('oauth2state')) {
+                if (!$this->hasAlreadyBounced()) {
+                    return $this->renderSameSiteBounce($this->buildBounceUrl());
+                }
+                // Already bounced once and the session is still missing: this is
+                // a genuine session loss (expired, cookies disabled, ...), fail clean.
+                throw new \Exception('Invalid state');
+
             // Check given state against previously stored one to mitigate CSRF attack
-            // Also reject when oauth2state is absent: missing session = missing pkceCode = invalid_grant on token exchange
-            } elseif (empty($state) || !$session->has('oauth2state') || $state !== $session->get('oauth2state')) {
+            } elseif ($state !== $session->get('oauth2state')) {
                 $session->remove('oauth2state');
 
                 throw new \Exception('Invalid state');
@@ -167,6 +198,54 @@ trait OAuth2LoginTrait
                 }
             }
         });
+    }
+
+    /**
+     * Whether the current callback is already the result of a same-site bounce.
+     * Guards against an infinite redirect loop when the session is genuinely lost.
+     *
+     * @return bool
+     */
+    private function hasAlreadyBounced()
+    {
+        return (bool) Tools::getValue('__ps_oauth_retry');
+    }
+
+    /**
+     * Rebuild the current callback URL, preserving every query param (code,
+     * state, action, ...) and adding the one-shot bounce marker. The returned
+     * URL is same-origin, so navigating to it client-side is a same-site
+     * request that carries the (Strict) admin cookie.
+     *
+     * @return string
+     */
+    private function buildBounceUrl()
+    {
+        $params = $_GET;
+        $params['__ps_oauth_retry'] = '1';
+
+        $path = strtok($_SERVER['REQUEST_URI'], '?');
+
+        return $path . '?' . http_build_query($params);
+    }
+
+    /**
+     * Minimal same-origin HTML page that re-navigates to $url. location.replace
+     * avoids polluting the history; the <noscript> meta-refresh is a fallback.
+     * $url is escaped for both the JS string and the HTML attribute contexts
+     * because it carries attacker-influenceable query params (code/state).
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    private function buildBounceHtml($url)
+    {
+        return '<!DOCTYPE html><html><head><meta charset="utf-8">'
+            . '<noscript><meta http-equiv="refresh" content="0;url='
+            . htmlspecialchars($url, ENT_QUOTES) . '"></noscript>'
+            . '<script type="text/javascript">window.location.replace('
+            . json_encode($url) . ');</script></head><body></body></html>';
     }
 
     /**

--- a/src/AccountLogin/OAuth2LoginTrait.php
+++ b/src/AccountLogin/OAuth2LoginTrait.php
@@ -142,7 +142,8 @@ trait OAuth2LoginTrait
                 $this->oauth2Redirect(Tools::getValue('locale', 'en'), $shopId);
 
             // Check given state against previously stored one to mitigate CSRF attack
-            } elseif (empty($state) || ($session->has('oauth2state') && $state !== $session->get('oauth2state'))) {
+            // Also reject when oauth2state is absent: missing session = missing pkceCode = invalid_grant on token exchange
+            } elseif (empty($state) || !$session->has('oauth2state') || $state !== $session->get('oauth2state')) {
                 $session->remove('oauth2state');
 
                 throw new \Exception('Invalid state');

--- a/src/AccountLogin/OAuth2LoginTrait.php
+++ b/src/AccountLogin/OAuth2LoginTrait.php
@@ -158,7 +158,6 @@ trait OAuth2LoginTrait
                 $session->remove('oauth2state');
 
                 throw new \Exception('Invalid state');
-
             // Session lost on the callback: oauth2state (and pkceCode) are gone.
             // The most common cause is PS_COOKIE_SAMESITE=Strict — the browser
             // withholds the admin cookie on the cross-site redirect back from
@@ -172,7 +171,6 @@ trait OAuth2LoginTrait
                 // Already bounced once and the session is still missing: this is
                 // a genuine session loss (expired, cookies disabled, ...), fail clean.
                 throw new \Exception('Invalid state');
-
             // Check given state against previously stored one to mitigate CSRF attack
             } elseif ($state !== $session->get('oauth2state')) {
                 $session->remove('oauth2state');

--- a/src/AccountLogin/OAuth2LoginTrait.php
+++ b/src/AccountLogin/OAuth2LoginTrait.php
@@ -449,6 +449,27 @@ trait OAuth2LoginTrait
     }
 
     /**
+     * Remove only the transient OAuth2 keys from the session, leaving every other
+     * attribute untouched. On PS 1.7+ getSession() is the core BO session, so a
+     * full clear() would sign the employee out at the end of the point-of-contact
+     * flow; clearing just our own keys avoids that.
+     *
+     * @return void
+     */
+    private function clearOAuth2SessionState()
+    {
+        $session = $this->getSession();
+
+        $session->remove('oauth2state');
+        $session->remove('oauth2pkceCode');
+        $session->remove('oauth2action');
+        $session->remove('source');
+        $session->remove('shopId');
+        $session->remove('forceSignup');
+        $session->remove($this->getReturnToParam());
+    }
+
+    /**
      * @param string $uid
      * @param string $email
      *

--- a/src/AccountLogin/OAuth2SessionKeys.php
+++ b/src/AccountLogin/OAuth2SessionKeys.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\PsAccounts\AccountLogin;
+
+use PrestaShop\Module\PsAccounts\Type\Enum;
+
+/**
+ * Transient session keys written during the OAuth2 login flow. Single source of
+ * truth: any new transient key added here is automatically cleared by
+ * OAuth2LoginTrait::clearOAuth2SessionState() via Enum::values().
+ *
+ * Keep this enum scoped to keys that must be purged at the end of a flow. A
+ * non-transient key (e.g. loginError) must NOT be listed here, or it would be
+ * wrongly removed by clearOAuth2SessionState().
+ */
+class OAuth2SessionKeys extends Enum
+{
+    const STATE = 'oauth2state';
+    const PKCE_CODE = 'oauth2pkceCode';
+    const ACTION = 'oauth2action';
+    const SOURCE = 'source';
+    const SHOP_ID = 'shopId';
+    const FORCE_SIGNUP = 'forceSignup';
+    const RETURN_TO = 'return_to';
+}

--- a/src/Controller/Admin/OAuth2Controller.php
+++ b/src/Controller/Admin/OAuth2Controller.php
@@ -319,6 +319,16 @@ class OAuth2Controller extends FrameworkBundleAdminController
     }
 
     /**
+     * @param string $url
+     *
+     * @return Response
+     */
+    protected function renderSameSiteBounce($url)
+    {
+        return (new Response())->setContent($this->buildBounceHtml($url));
+    }
+
+    /**
      * @param bool $forceSignup
      *
      * @return Response

--- a/src/Polyfill/ConfigurationStorageSession.php
+++ b/src/Polyfill/ConfigurationStorageSession.php
@@ -205,7 +205,7 @@ class ConfigurationStorageSession
         $session = $this->all();
         unset($session[$name]);
 
-        $this->configuration->set($name, json_encode($session));
+        $this->configuration->set($this->getConfigurationName(), json_encode($session));
     }
 
     /**

--- a/tests/src/Unit/AccountLogin/OAuth2LoginTraitTest.php
+++ b/tests/src/Unit/AccountLogin/OAuth2LoginTraitTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace PrestaShop\Module\PsAccounts\Tests\Unit\AccountLogin;
+
+use PrestaShop\Module\PsAccounts\AccountLogin\OAuth2Session;
+use PrestaShop\Module\PsAccounts\Service\OAuth2\OAuth2Service;
+use PrestaShop\Module\PsAccounts\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class OAuth2LoginTraitTest extends TestCase
+{
+    public function set_up()
+    {
+        parent::set_up();
+
+        // OAuth2Controller (and the Symfony session it relies on) only exists on PS 1.7+
+        if (false === version_compare(_PS_VERSION_, '1.7', '>=')) {
+            $this->markTestSkipped('OAuth2 controller / Symfony session only available on PS 1.7+');
+        }
+    }
+
+    public function tear_down()
+    {
+        // Tools::getValue reads $_POST + $_GET: clean up so other tests aren't polluted
+        unset($_GET['shop_id'], $_GET['code'], $_GET['state']);
+        unset($_POST['shop_id'], $_POST['code'], $_POST['state']);
+
+        parent::tear_down();
+    }
+
+    /**
+     * A callback carrying a valid code + state but landing on a request whose session lost
+     * the stored oauth2state must be rejected before any token exchange: a missing session
+     * means a missing pkceCode, which would otherwise trigger a cryptic invalid_grant.
+     *
+     * @test
+     */
+    public function itShouldRejectCallbackWhenSessionIsMissing()
+    {
+        $session = $this->createSessionDouble(false, null);
+
+        $this->whenCallbackReceives('somevalidcode', 'state-from-callback');
+
+        $instance = $this->createInstance($session, $this->createOAuth2ServiceNeverCalled());
+
+        $session->expects($this->once())->method('remove')->with('oauth2state');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid state');
+
+        $instance->oauth2Login();
+    }
+
+    /**
+     * A callback whose state does not match the one stored in session (CSRF mitigation) must
+     * be rejected before any token exchange.
+     *
+     * @test
+     */
+    public function itShouldRejectCallbackWhenStateDoesNotMatch()
+    {
+        $session = $this->createSessionDouble(true, 'a-different-state');
+
+        $this->whenCallbackReceives('somevalidcode', 'state-from-callback');
+
+        $instance = $this->createInstance($session, $this->createOAuth2ServiceNeverCalled());
+
+        $session->expects($this->once())->method('remove')->with('oauth2state');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid state');
+
+        $instance->oauth2Login();
+    }
+
+    /**
+     * @param string $code
+     * @param string $state
+     *
+     * @return void
+     */
+    private function whenCallbackReceives($code, $state)
+    {
+        $_GET['shop_id'] = \Context::getContext()->shop->id;
+        $_GET['code'] = $code;
+        $_GET['state'] = $state;
+    }
+
+    /**
+     * @param bool $hasState whether the session holds an oauth2state key
+     * @param string|null $storedState value returned for get('oauth2state')
+     *
+     * @return SessionInterface
+     */
+    private function createSessionDouble($hasState, $storedState)
+    {
+        $session = $this->createMock(SessionInterface::class);
+
+        $session->method('has')->willReturnCallback(function ($key) use ($hasState) {
+            return 'oauth2state' === $key ? $hasState : false;
+        });
+
+        // getShopId() calls get('shopId') eagerly (default arg of Tools::getValue) — answer null
+        $session->method('get')->willReturnCallback(function ($key, $default = null) use ($storedState) {
+            return 'oauth2state' === $key ? $storedState : $default;
+        });
+
+        return $session;
+    }
+
+    /**
+     * The discriminating assertion: the token exchange (with the missing pkceCode) is the
+     * exact call the fix prevents, so it must never be reached on a rejected callback.
+     *
+     * @return OAuth2Service
+     */
+    private function createOAuth2ServiceNeverCalled()
+    {
+        $oauth2Service = $this->createMock(OAuth2Service::class);
+        $oauth2Service->expects($this->never())->method('getAccessTokenByAuthorizationCode');
+
+        return $oauth2Service;
+    }
+
+    /**
+     * @param SessionInterface $session
+     * @param OAuth2Service $oauth2Service
+     *
+     * @return OAuth2LoginTraitTestClass
+     */
+    private function createInstance($session, $oauth2Service)
+    {
+        return new OAuth2LoginTraitTestClass(
+            $this->module,
+            $session,
+            $oauth2Service,
+            $this->createMock(OAuth2Session::class)
+        );
+    }
+}

--- a/tests/src/Unit/AccountLogin/OAuth2LoginTraitTest.php
+++ b/tests/src/Unit/AccountLogin/OAuth2LoginTraitTest.php
@@ -22,20 +22,22 @@ class OAuth2LoginTraitTest extends TestCase
     public function tear_down()
     {
         // Tools::getValue reads $_POST + $_GET: clean up so other tests aren't polluted
-        unset($_GET['shop_id'], $_GET['code'], $_GET['state']);
-        unset($_POST['shop_id'], $_POST['code'], $_POST['state']);
+        unset($_GET['shop_id'], $_GET['code'], $_GET['state'], $_GET['__ps_oauth_retry']);
+        unset($_POST['shop_id'], $_POST['code'], $_POST['state'], $_POST['__ps_oauth_retry']);
+        unset($_SERVER['REQUEST_URI']);
 
         parent::tear_down();
     }
 
     /**
      * A callback carrying a valid code + state but landing on a request whose session lost
-     * the stored oauth2state must be rejected before any token exchange: a missing session
-     * means a missing pkceCode, which would otherwise trigger a cryptic invalid_grant.
+     * the stored oauth2state is the PS_COOKIE_SAMESITE=Strict symptom: instead of failing,
+     * the flow must emit a same-site bounce (re-navigation) to recover the cookie, without
+     * ever attempting the token exchange (which would lack the pkceCode).
      *
      * @test
      */
-    public function itShouldRejectCallbackWhenSessionIsMissing()
+    public function itShouldBounceWhenSessionIsMissing()
     {
         $session = $this->createSessionDouble(false, null);
 
@@ -43,11 +45,41 @@ class OAuth2LoginTraitTest extends TestCase
 
         $instance = $this->createInstance($session, $this->createOAuth2ServiceNeverCalled());
 
-        $session->expects($this->once())->method('remove')->with('oauth2state');
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Invalid state');
+        $result = $instance->oauth2Login();
 
-        $instance->oauth2Login();
+        $this->assertSame('same-site-bounce', $result);
+        $this->assertNotNull($instance->bouncedUrl);
+        $this->assertStringContainsString('code=somevalidcode', $instance->bouncedUrl);
+        $this->assertStringContainsString('state=state-from-callback', $instance->bouncedUrl);
+        $this->assertStringContainsString('__ps_oauth_retry=1', $instance->bouncedUrl);
+    }
+
+    /**
+     * If the session is still missing after a bounce already happened (__ps_oauth_retry=1),
+     * this is a genuine session loss: reject before any token exchange instead of looping.
+     *
+     * @test
+     */
+    public function itShouldRejectCallbackWhenSessionStillMissingAfterBounce()
+    {
+        $session = $this->createSessionDouble(false, null);
+
+        $this->whenCallbackReceives('somevalidcode', 'state-from-callback');
+        $_GET['__ps_oauth_retry'] = '1';
+
+        $instance = $this->createInstance($session, $this->createOAuth2ServiceNeverCalled());
+
+        $thrown = null;
+        try {
+            $instance->oauth2Login();
+        } catch (\Exception $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(\Exception::class, $thrown);
+        $this->assertSame('Invalid state', $thrown->getMessage());
+        // No second bounce was emitted: the guard turned the retry into a clean failure.
+        $this->assertNull($instance->bouncedUrl);
     }
 
     /**
@@ -82,6 +114,9 @@ class OAuth2LoginTraitTest extends TestCase
         $_GET['shop_id'] = \Context::getContext()->shop->id;
         $_GET['code'] = $code;
         $_GET['state'] = $state;
+
+        // buildBounceUrl() rebuilds the current callback URL from REQUEST_URI + $_GET
+        $_SERVER['REQUEST_URI'] = '/admin/index.php?controller=AdminOAuth2PsAccounts';
     }
 
     /**

--- a/tests/src/Unit/AccountLogin/OAuth2LoginTraitTestClass.php
+++ b/tests/src/Unit/AccountLogin/OAuth2LoginTraitTestClass.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace PrestaShop\Module\PsAccounts\Tests\Unit\AccountLogin;
+
+use PrestaShop\Module\PsAccounts\AccountLogin\OAuth2LoginTrait;
+use PrestaShop\Module\PsAccounts\Service\OAuth2\Resource\AccessToken;
+
+/**
+ * Concrete host exposing OAuth2LoginTrait so it can be exercised in unit tests.
+ *
+ * Collaborators returned by the trait's abstract methods are injected through the
+ * constructor so each test can supply its own doubles.
+ */
+class OAuth2LoginTraitTestClass
+{
+    use OAuth2LoginTrait;
+
+    public $module;
+
+    private $session;
+
+    private $oauth2Service;
+
+    private $oauth2Session;
+
+    public function __construct($module, $session, $oauth2Service, $oauth2Session)
+    {
+        $this->module = $module;
+        $this->session = $session;
+        $this->oauth2Service = $oauth2Service;
+        $this->oauth2Session = $oauth2Session;
+    }
+
+    protected function getOAuth2Service()
+    {
+        return $this->oauth2Service;
+    }
+
+    protected function initUserSession(AccessToken $accessToken)
+    {
+        return false;
+    }
+
+    protected function redirectAfterLogin()
+    {
+        return 'redirect-after-login';
+    }
+
+    protected function logout()
+    {
+        return null;
+    }
+
+    protected function onLoginFailedRedirect()
+    {
+        return 'login-failed-redirect';
+    }
+
+    protected function getSession()
+    {
+        return $this->session;
+    }
+
+    protected function getOauth2Session()
+    {
+        return $this->oauth2Session;
+    }
+
+    protected function getAnalyticsService()
+    {
+        return null;
+    }
+
+    protected function getPsAccountsService()
+    {
+        return null;
+    }
+
+    protected function getSignupUrl()
+    {
+        return '';
+    }
+}

--- a/tests/src/Unit/AccountLogin/OAuth2LoginTraitTestClass.php
+++ b/tests/src/Unit/AccountLogin/OAuth2LoginTraitTestClass.php
@@ -23,12 +23,27 @@ class OAuth2LoginTraitTestClass
 
     private $oauth2Session;
 
+    /**
+     * Records the URL passed to renderSameSiteBounce() so tests can assert on it
+     * (the real controllers echo+exit / return a Response instead).
+     *
+     * @var string|null
+     */
+    public $bouncedUrl = null;
+
     public function __construct($module, $session, $oauth2Service, $oauth2Session)
     {
         $this->module = $module;
         $this->session = $session;
         $this->oauth2Service = $oauth2Service;
         $this->oauth2Session = $oauth2Session;
+    }
+
+    protected function renderSameSiteBounce($url)
+    {
+        $this->bouncedUrl = $url;
+
+        return 'same-site-bounce';
     }
 
     protected function getOAuth2Service()

--- a/upgrade/upgrade-8.0.16.php
+++ b/upgrade/upgrade-8.0.16.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @param Ps_accounts $module
+ *
+ * @return bool
+ *
+ * @throws Exception
+ * @throws Throwable
+ */
+function upgrade_module_8_0_16($module)
+{
+    require_once __DIR__ . '/helpers.php';
+
+    migrate_or_create_identities_v8($module, '8.0.16');
+
+    return true;
+}


### PR DESCRIPTION
## Context

PrestaShop's **Advanced Parameters → Administration → General → Cookie SameSite** setting (`PS_COOKIE_SAMESITE`) defaults to `Lax`. When a merchant hardens it to `Strict`, the module's OAuth2 flows break:

- **BO login** via PrestaShop Account
- **Point-of-contact identification** (`action=identifyPointOfContact`)

`Lax` (default) and `None` (+ HTTPS/`Secure`) work; only `Strict` breaks the flow.

## Root cause

The OAuth2 (authorization code + PKCE) flow stores `oauth2state`/`oauth2pkceCode` in the BO session before redirecting to auth-hydra. On return, auth-hydra `302`s back to our callback — a **cross-site top-level navigation**. With `Strict` the browser **withholds** the admin/session cookie on that return, so the callback runs on an **empty session** (lost `oauth2state`/`pkceCode`, and the employee isn't authenticated). It initially surfaced as an opaque `invalid_grant` (token exchange with a `null` `code_verifier`).

A server can't fix an incoming request that carries no cookie — **except** by replaying it as a *same-site* request, where `Strict` does send the cookie.

## Fix

### 1. Defensive rejection (clean failure)
`OAuth2LoginTrait` — a missing `oauth2state` is rejected **before** any token exchange (no opaque `invalid_grant`, no silent CSRF bypass on a lost session).

### 2. Same-site bounce recovery
When the callback detects a lost session (`!has('oauth2state')`) with `code`+`state` present, it serves a same-origin page that re-navigates (`location.replace`) to the same callback URL — preserving `code`/`state` + a one-shot `__ps_oauth_retry=1` marker. The replay is **same-site**, so `Strict` sends the cookie → session restored → flow completes. Guard: if the marker is already set and the session is still empty → clean `Invalid state` (one extra hop, no loop). CSRF state check stays active; URL escaped for JS (`json_encode`) and HTML (`htmlspecialchars`, `ENT_QUOTES`).

### 3. Cookie preservation on the bounce (PS < 9)
The bounce is a dead-end page that must set **no** cookie. Two parasitic writes are neutralized in `AdminOAuth2PsAccountsController::renderSameSiteBounce()`:
- `header_remove('Set-Cookie')` — drops the empty Symfony session cookie minted by the first session access.
- `Context::cookie->disallowWriting()` — the employee cookie isn't sent on the cross-site return, so PrestaShop builds an anonymous `Cookie` whose `write()` runs on `__destruct` (during `exit`, after `header_remove`, and with BO output buffering `headers_sent()` is still false → it would re-emit an anonymous admin cookie that overwrites the real one). This was the specific cause of the point-of-contact logout: login recovered (it rewrites a fresh employee cookie) but point of contact never does.

### 4. Point of contact: core session + targeted clear (PS 1.7+)
`getSession()` previously forced `ConfigurationStorageSession` (DB store keyed by `id_fallback_session` in the employee cookie) whenever `employee->id` was set — which made the bounce inoperative under `Strict` (employee absent on the return). That fallback only existed to survive the final `getSession()->clear()` in the point-of-contact path (a full clear of the core BO session logs the employee out). Decoupled:
- `clearOAuth2SessionState()` removes **only** the transient OAuth keys (`oauth2state`, `oauth2pkceCode`, `oauth2action`, `source`, `shopId`, `forceSignup`, `return_to`), never the whole session; `redirectAfterLogin()` uses it instead of `getSession()->clear()`.
- `getSession()` now returns `module->getSession()`, which yields `ConfigurationStorageSession` **only on PS 1.6** (no core container) and the core session on PS 1.7+. Point of contact shares the login session → the bounce works for both flows.
- Fixed a latent bug in `ConfigurationStorageSession::remove()` (wrote to the attribute name instead of the session row).

### 5. Code quality
`oauth2Login()` refactored (SonarCloud): validation+exchange extracted into `handleAuthorizationCode()`, rejection centralized in `rejectInvalidState()`, and a dedicated `InvalidOAuth2StateException` replaces the generic `\Exception` (kept extending `\Exception` so the controllers' catch path is unchanged).

> **PS 9** (`OAuth2Controller`, Symfony `Response`, Symfony Security, no `exit`, no fallback) is **unaffected** throughout — it already worked.

## Files

- `src/AccountLogin/OAuth2LoginTrait.php` — bounce + helpers + refactor + `clearOAuth2SessionState()`
- `controllers/admin/AdminOAuth2PsAccountsController.php` (PS < 9) — `renderSameSiteBounce()` (`disallowWriting` + `header_remove` + `echo`/`exit`), `getSession()` scoping, targeted clear
- `src/Controller/Admin/OAuth2Controller.php` (PS 9+) — `renderSameSiteBounce()` → `Response`
- `src/AccountLogin/Exception/InvalidOAuth2StateException.php` — new
- `src/Polyfill/ConfigurationStorageSession.php` — `remove()` bug fix
- `doc/oauth2-samesite-strict.md` — full diagnosis + fix
- `tests/src/Unit/AccountLogin/OAuth2LoginTraitTest.php` (+ `OAuth2LoginTraitTestClass.php`)

## Test plan

- [x] **E2E PS 9 + `Strict`** — login & point of contact ✅
- [x] **E2E PS 8 + `Strict`** — login & point of contact (popup), employee stays logged in ✅
- [x] **E2E PS 1.7 + `Strict`** — login & point of contact ✅
- [x] Non-regression on `Lax`
- [x] `php-cs-fixer` + PHPStan (level 7) clean
- [ ] Unit tests `OAuth2LoginTraitTest` (CI, PS ≥ 1.7): bounce / reject-after-bounce / CSRF mismatch
- [ ] PS 1.6 sanity check (point of contact; `getSession()` → `ConfigurationStorageSession` as before)

## Recommendation

`Lax` remains recommended (and is the PrestaShop default). Under `Strict`, login **and** point of contact are now supported via the same-site bounce (one invisible extra redirect), validated E2E on PS 9 / 8 / 1.7.

> ⚠️ Touches the restricted `src/AccountLogin/` (auth/session) area — mandatory review.

## Links

- Jira: ACC-3420
- Doc: `doc/oauth2-samesite-strict.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
