### PR TITLE
[ACC-3223] fix(e2e): update stale authv2-preprod URL assertion in popupAccountPage

### DIFF
--- a/e2e/pages/configureAccount/configureAccountPage.ts
+++ b/e2e/pages/configureAccount/configureAccountPage.ts
@@ -80,7 +80,7 @@ export default class ConfigureAccountPage extends ModuleManagerPage {
     ]);
 
     await newPage.waitForTimeout(5000);
-    // expect(newPage.url()).toContain('authv2-preprod');
+    // expect(newPage.url()).toContain('authv2.preproduction');
     return newPage;
   }
 

--- a/e2e/pages/popupAccount/popupAccountPage.ts
+++ b/e2e/pages/popupAccount/popupAccountPage.ts
@@ -21,7 +21,7 @@ export default class PopupAccountPage extends ModuleManagerPage {
     ]);
 
     await newPage.waitForTimeout(5000);
-    expect(newPage.url()).toContain('authv2-preprod');
+    expect(newPage.url()).toContain('authv2.preproduction');
     return newPage;
   }
 

--- a/e2e/pages/popupAccount/popupAccountPage.ts
+++ b/e2e/pages/popupAccount/popupAccountPage.ts
@@ -36,7 +36,7 @@ export default class PopupAccountPage extends ModuleManagerPage {
     ]);
 
     await newPage.waitForTimeout(5000);
-    // expect(newPage.url()).toContain('authv2-preprod');
+    // expect(newPage.url()).toContain('authv2.preproduction');
     return newPage;
   }
 


### PR DESCRIPTION
## Contexte

Le run [e2e Acounts V7 TNRs](https://github.com/PrestaShopCorp/ps_accounts/actions/runs/27814466769) apparaît vert (`continue-on-error` masque les échecs) mais contient **3 échecs `failed`** réels sur les 4 plateformes : les specs TNR V7 d'association/désassociation.

## Cause

`PopupAccountPage.openAccountPopup()` asserte une sous-chaîne d'URL périmée :

```ts
expect(newPage.url()).toContain('authv2-preprod');
```

Le domaine d'auth préprod a changé : l'URL réelle retournée par la popup est désormais `https://authv2.preproduction.***.com/login?...`. La sous-chaîne `authv2-preprod` ne correspond donc plus → l'assertion échoue juste après l'ouverture de la popup, et l'association ne se termine jamais (d'où aussi les cascades sur la désassociation).

## Correctif

`authv2-preprod` → `authv2.preproduction` (ligne 24), cohérent avec le format pointé déjà utilisé ligne 188 (`accounts.distribution-preprod`) et avec ce que retournent **toutes** les plateformes du run.

## Portée

- Corrige les 3 échecs d'assertion sur 8.2.0 / 1.7.8.8 / 1.6.1.24 et débloque les cascades de désassociation.
- N'affecte **pas** les échecs nightly (PS 9) : ceux-ci proviennent de la version pinnée v7.2.2 installée par le V7 TNR, incompatible PS 9 — sujet de matrice CI distinct, pas de régression du code courant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)