### PR TITLE
[ACC-3465] feat(accounts): Store↔Organisation attachment & POC before verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ If you are integrating a module, you should have a look on the [PrestaShop Integ
 
 #### Tokens availability with legacy compatibility table
 
-| Method Name             | PrestaShop AccessToken | Scopes        | **_Legacy_**<br/>Firebase Shop Id Token | **_Legacy_**<br/>Firebase User Id Token |
-|-------------------------|------------------------|---------------|-----------------------------------------|-----------------------------------------|
-| **_>= v8.0.0_**         |                        |               |                                         |                                         |
-| isShopIdentityCreated   | Yes                    |               | Yes                                     | No                                      |
-| isShopIdentityVerified  | Yes                    | shop.verified | Yes                                     | No                                      |
-| isShopPointOfContactSet | Yes                    | shop.verified | Yes                                     | Yes                                     |
-| **_< v8.0.0_**          |                        |               |                                         |                                         |
-| isAccountLinked         | Yes                    | shop.verified | Yes                                     | Yes                                     |
+| Method Name             | PrestaShop AccessToken | Scopes | **_Legacy_**<br/>Firebase Shop Id Token | **_Legacy_**<br/>Firebase User Id Token |
+|-------------------------|------------------------|--------|-----------------------------------------|-----------------------------------------|
+| **_>= v8.0.0_**         |                        |        |                                         |                                         |
+| isShopIdentityCreated   | Yes                    |        | Yes                                     | No                                      |
+| isShopIdentityVerified  | Yes                    |        | Yes                                     | No                                      |
+| isShopPointOfContactSet | Yes                    |        | Yes                                     | Yes                                     |
+| **_< v8.0.0_**          |                        |        |                                         |                                         |
+| isAccountLinked         | Yes                    |        | Yes                                     | Yes                                     |
 
 
 ### How to get up-to-date JWT Shop Access Tokens

--- a/src/Account/CommandHandler/IdentifyContactHandler.php
+++ b/src/Account/CommandHandler/IdentifyContactHandler.php
@@ -76,11 +76,6 @@ class IdentifyContactHandler
      */
     public function handle(IdentifyContactCommand $command)
     {
-        $status = $this->statusManager->withSource($command->source)->getStatus();
-        if (!$status->isVerified) {
-            return;
-        }
-
         $this->accountsService
             ->withSource($command->source)
             ->setPointOfContact(

--- a/src/Account/Session/ShopSession.php
+++ b/src/Account/Session/ShopSession.php
@@ -72,21 +72,23 @@ class ShopSession extends Session implements SessionInterface
     }
 
     /**
-     * When $scope / $audience are omitted, shop-specific defaults are resolved
-     * (verified scope + store audience). When passed explicitly — including an
-     * empty array — they are forwarded as-is, so a caller can force an empty
-     * scope/audience independently of the shop verified state.
+     * When $audience is omitted, the shop-specific default is resolved (store
+     * audience). When passed explicitly — including an empty array — it is
+     * forwarded as-is, so a caller can force an empty audience.
+     *
+     * $scope has no shop-specific default: the shop.verified scope machinery was
+     * removed (ACC-3465), so an omitted scope forwards the empty default unchanged.
      *
      * Note: func_num_args() is used (rather than a null default) to tell an
      * omitted argument apart from an explicit "[]" while keeping the array type
      * hint. This avoids both the PHP 8.4 implicitly-nullable deprecation (removed
      * in PHP 9.0) and the pre-7.2 "Declaration should be compatible" variance
-     * warning against the parent/interface signature (array $scope = []).
+     * warning against the parent/interface signature (array $audience = []).
      *
      * @param bool $forceRefresh
      * @param bool $throw
-     * @param array $scope omit for shop defaults; pass (even []) to force it
-     * @param array $audience omit for shop defaults; pass (even []) to force it
+     * @param array $scope
+     * @param array $audience omit for shop default; pass (even []) to force it
      *
      * @return Token
      *
@@ -94,13 +96,7 @@ class ShopSession extends Session implements SessionInterface
      */
     public function getValidToken($forceRefresh = false, $throw = true, array $scope = [], array $audience = [])
     {
-        $argc = func_num_args();
-
-        if ($argc < 3) {
-            $scope = [];
-        }
-
-        if ($argc < 4) {
+        if (func_num_args() < 4) {
             $audience = [
                 'store/' . $this->getStatusManager()->getCloudShopId(),
                 $this->tokenAudience,

--- a/src/Account/Session/ShopSession.php
+++ b/src/Account/Session/ShopSession.php
@@ -72,15 +72,12 @@ class ShopSession extends Session implements SessionInterface
     }
 
     /**
-     * When $audience is omitted, the shop-specific default is resolved (store
-     * audience). When passed explicitly — including an empty array — it is
-     * forwarded as-is, so a caller can force an empty audience.
-     *
-     * $scope has no shop-specific default: the shop.verified scope machinery was
-     * removed (ACC-3465), so an omitted scope forwards the empty default unchanged.
+     * Resolves the shop store audience when $audience is omitted. When passed
+     * explicitly — including an empty array — it is forwarded as-is, so a caller
+     * can force an empty audience. $scope is always forwarded unchanged.
      *
      * Note: func_num_args() is used (rather than a null default) to tell an
-     * omitted argument apart from an explicit "[]" while keeping the array type
+     * omitted $audience apart from an explicit "[]" while keeping the array type
      * hint. This avoids both the PHP 8.4 implicitly-nullable deprecation (removed
      * in PHP 9.0) and the pre-7.2 "Declaration should be compatible" variance
      * warning against the parent/interface signature (array $audience = []).
@@ -88,7 +85,7 @@ class ShopSession extends Session implements SessionInterface
      * @param bool $forceRefresh
      * @param bool $throw
      * @param array $scope
-     * @param array $audience omit for shop default; pass (even []) to force it
+     * @param array $audience omit to resolve the shop store audience; pass (even []) to force it
      *
      * @return Token
      *

--- a/src/Account/Session/ShopSession.php
+++ b/src/Account/Session/ShopSession.php
@@ -24,9 +24,7 @@ use PrestaShop\Module\PsAccounts\Account\Exception\RefreshTokenException;
 use PrestaShop\Module\PsAccounts\Account\Token\Token;
 use PrestaShop\Module\PsAccounts\Hook\ActionShopAccessTokenRefreshAfter;
 use PrestaShop\Module\PsAccounts\Repository\ConfigurationRepository;
-use PrestaShop\Module\PsAccounts\Service\OAuth2\Exception\InvalidScopeException;
 use PrestaShop\Module\PsAccounts\Service\OAuth2\OAuth2Exception;
-use PrestaShop\Module\PsAccounts\Service\OAuth2\OAuth2ServerException;
 use PrestaShop\Module\PsAccounts\Service\OAuth2\OAuth2Service;
 use PrestaShop\Module\PsAccounts\Service\OAuth2\Resource\AccessToken;
 
@@ -86,9 +84,7 @@ class ShopSession extends Session implements SessionInterface
     public function getValidToken($forceRefresh = false, $throw = true, array $scope = null, array $audience = null)
     {
         if ($scope === null) {
-            $scope = ($this->getStatusManager()->identityVerified() ? [
-                'shop.verified',
-            ] : []);
+            $scope = [];
         }
 
         if ($audience === null) {
@@ -113,11 +109,7 @@ class ShopSession extends Session implements SessionInterface
     public function refreshToken($refreshToken = null, array $scope = [], array $audience = [])
     {
         try {
-            try {
-                $accessToken = $this->getAccessToken($scope, $audience);
-            } catch (InvalidScopeException $e) {
-                $accessToken = $this->fallbackRefresh($e, 'shop.verified', $scope, $audience);
-            }
+            $accessToken = $this->getAccessToken($scope, $audience);
 
             $this->setToken(
                 $accessToken->access_token,
@@ -188,32 +180,5 @@ class ShopSession extends Session implements SessionInterface
     protected function getAccessToken(array $scope = [], array $audience = [])
     {
         return $this->oAuth2Service->getAccessTokenByClientCredentials($scope, $audience);
-    }
-
-    /**
-     * @param OAuth2ServerException $e
-     * @param string $filterScope
-     * @param array $scope
-     * @param array $audience
-     *
-     * @return AccessToken
-     *
-     * @throws OAuth2Exception
-     */
-    protected function fallbackRefresh($e, $filterScope, array $scope, array $audience)
-    {
-        if (in_array($filterScope, $scope) &&
-            str_contains($e->getMessage(), $filterScope)
-        ) {
-            $this->getStatusManager()->setIsVerified(false);
-            $this->resetRefreshTokenErrors();
-            $accessToken = $this->getAccessToken(array_filter($scope, function ($scp) use ($filterScope) {
-                return $scp !== $filterScope;
-            }), $audience);
-        } else {
-            throw $e;
-        }
-
-        return $accessToken;
     }
 }

--- a/src/Account/StatusManager.php
+++ b/src/Account/StatusManager.php
@@ -300,6 +300,62 @@ class StatusManager
     }
 
     /**
+     * @param bool $cachedStatus
+     *
+     * @return string|null
+     */
+    public function getOrganizationId($cachedStatus = true)
+    {
+        try {
+            return $this->getStatus($cachedStatus)->organizationId;
+        } catch (UnknownStatusException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param bool $cachedStatus
+     *
+     * @return string|null
+     */
+    public function getOrganizationName($cachedStatus = true)
+    {
+        try {
+            return $this->getStatus($cachedStatus)->organizationName;
+        } catch (UnknownStatusException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param bool $cachedStatus
+     *
+     * @return string|null
+     */
+    public function getPointOfContactRole($cachedStatus = true)
+    {
+        try {
+            return $this->getStatus($cachedStatus)->pointOfContactRole;
+        } catch (UnknownStatusException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param bool $cachedStatus
+     *
+     * @return string|null
+     */
+    public function getShopEnvironment($cachedStatus = true)
+    {
+        try {
+            return $this->getStatus($cachedStatus)->shopEnvironment;
+        } catch (UnknownStatusException $e) {
+            return null;
+        }
+    }
+
+    /**
      * @param string $pointOfContactEmail
      *
      * @return void

--- a/src/Service/Accounts/Resource/ShopStatus.php
+++ b/src/Service/Accounts/Resource/ShopStatus.php
@@ -61,6 +61,26 @@ class ShopStatus extends Resource
     public $pointOfContactEmail;
 
     /**
+     * @var string
+     */
+    public $organizationId;
+
+    /**
+     * @var string
+     */
+    public $organizationName;
+
+    /**
+     * @var string
+     */
+    public $pointOfContactRole;
+
+    /**
+     * @var string
+     */
+    public $shopEnvironment;
+
+    /**
      * @var DateTime|null
      */
     public $createdAt;

--- a/src/Service/PsAccountsService.php
+++ b/src/Service/PsAccountsService.php
@@ -207,6 +207,38 @@ class PsAccountsService
     }
 
     /**
+     * @return string|null
+     */
+    public function getOrganizationId()
+    {
+        return $this->statusManager->getOrganizationId();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOrganizationName()
+    {
+        return $this->statusManager->getOrganizationName();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPointOfContactRole()
+    {
+        return $this->statusManager->getPointOfContactRole();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getShopEnvironment()
+    {
+        return $this->statusManager->getShopEnvironment();
+    }
+
+    /**
      * @return bool
      *
      * @deprecated since v8.0.0

--- a/tests/src/Unit/Account/CommandHandler/IdentifyContactHandlerTest.php
+++ b/tests/src/Unit/Account/CommandHandler/IdentifyContactHandlerTest.php
@@ -115,7 +115,7 @@ class IdentifyContactHandlerTest extends TestCase
     /**
      * @test
      */
-    public function itShouldNotSaveIdentityContactOnShopNotVerified()
+    public function itShouldSaveIdentityContactEvenWhenShopNotVerified()
     {
         $cloudShopId = $this->faker->uuid;
 
@@ -123,8 +123,10 @@ class IdentifyContactHandlerTest extends TestCase
 
         $this->shopSession->method('getValidToken')->willReturn("valid_token");
 
-        // Expected call to setPointOfContact with correct parameters
-        $this->accountsService->expects($this->exactly(0))
+        $this->ownerSession->setToken($this->faker->uuid, $this->faker->uuid);
+
+        // POC must be set regardless of verification status (guard removed)
+        $this->accountsService->expects($this->once())
             ->method('setPointOfContact')
             ->with(
                 $this->equalTo($cloudShopId),
@@ -148,6 +150,12 @@ class IdentifyContactHandlerTest extends TestCase
         $this->getHandler()->handle(new IdentifyContactCommand(new AccessToken([
             'access_token' => 'valid_access_token',
         ]), $userInfo));
+
+        // POC persisted and verification state left untouched (still not verified)
+        $this->assertInstanceOf(NullToken::class, $this->ownerSession->getToken()->getJwt());
+        $this->assertEquals($userInfo->sub, $this->statusManager->getPointOfContactUuid());
+        $this->assertEquals($userInfo->email, $this->statusManager->getPointOfContactEmail());
+        $this->assertFalse($this->statusManager->identityVerified());
     }
 
     /**

--- a/tests/src/Unit/Account/Session/ShopSession/GetValidTokenTest.php
+++ b/tests/src/Unit/Account/Session/ShopSession/GetValidTokenTest.php
@@ -260,10 +260,11 @@ class GetValidTokenTest extends TestCase
 
         list($shopSession, $tokenAudience, $capture) = $this->makeCapturingShopSession();
 
-        // no scope/audience provided + forced refresh => defaults must be resolved
+        // no scope/audience provided + forced refresh => defaults must be resolved.
+        // shop.verified scope machinery removed (ACC-3465): default scope is now empty.
         $shopSession->getValidToken(true);
 
-        $this->assertEquals(['shop.verified'], $capture->scope);
+        $this->assertEquals([], $capture->scope);
         $this->assertEquals([
             'store/' . $this->cloudShopId,
             $tokenAudience,

--- a/tests/src/Unit/Account/Session/ShopSession/GetValidTokenTest.php
+++ b/tests/src/Unit/Account/Session/ShopSession/GetValidTokenTest.php
@@ -158,6 +158,39 @@ class GetValidTokenTest extends TestCase
         $this->assertEquals((string) $validAccessToken, (string) $this->shopSession->getValidToken());
     }
 
+    /**
+     * @test
+     *
+     * The shop.verified scope machinery has been removed: a verified shop no longer
+     * forces a refresh just to obtain a token bearing the shop.verified claim. A valid
+     * scopeless token must be accepted as-is.
+     */
+    public function itShouldNotRefreshScopelessTokenWhenVerified()
+    {
+        $this->configurationRepository->updateCachedShopStatus(json_encode((new CachedShopStatus([
+            'isValid' => true,
+            'updatedAt' => (new \DateTime())->format(\DateTime::ATOM),
+            'shopStatus' => new ShopStatus([
+                'cloudShopId' => $this->cloudShopId,
+                'isVerified' => true,
+            ])
+        ]))->toArray()));
+
+        $scopelessToken = $this->makeJwtToken(new \DateTimeImmutable('+1 hour'), [
+            'scp' => [
+                //'shop.verified',
+            ],
+            'aud' => [
+                $this->module->getParameter('ps_accounts.token_audience') . '/',
+                'store/' . $this->cloudShopId,
+            ],
+        ]);
+
+        $this->shopSession->setToken((string) $scopelessToken);
+
+        $this->assertEquals((string) $scopelessToken, (string) $this->shopSession->getValidToken());
+    }
+
     public function provideInvalidTokens()
     {
         $module = $this->getModuleInstance();
@@ -167,17 +200,6 @@ class GetValidTokenTest extends TestCase
                 $this->makeJwtToken(new \DateTimeImmutable('yesterday'), [
                     'scp' => [
                         'shop.verified',
-                    ],
-                    'aud' => [
-                        $module->getParameter('ps_accounts.token_audience'),
-                        'store/' . $this->cloudShopId,
-                    ]
-                ]),
-            ],
-            'invalid scope' => [
-                $this->makeJwtToken(new \DateTimeImmutable('tomorrow'), [
-                    'scp' => [
-                        //'shop.verified',
                     ],
                     'aud' => [
                         $module->getParameter('ps_accounts.token_audience'),

--- a/tests/src/Unit/Account/StatusManagerTest.php
+++ b/tests/src/Unit/Account/StatusManagerTest.php
@@ -244,4 +244,66 @@ class StatusManagerTest extends TestCase
         $this->assertFalse($cachedStatus->isVerified);
         $this->assertNull($cachedStatus->pointOfContactEmail);
     }
+
+    /**
+     * @test
+     */
+    public function itShouldExposeOrganizationAndEnvironmentFromCache()
+    {
+        $organizationId = $this->faker->uuid;
+        $organizationName = $this->faker->company;
+        $pointOfContactRole = 'owner';
+        $shopEnvironment = 'Test';
+
+        $this->configurationRepository->updateCachedShopStatus(json_encode((new CachedShopStatus([
+            'isValid' => true,
+            'updatedAt' => (new \DateTime())->format(\DateTime::ATOM),
+            'shopStatus' => new ShopStatus([
+                'cloudShopId' => $this->faker->uuid,
+                'organizationId' => $organizationId,
+                'organizationName' => $organizationName,
+                'pointOfContactRole' => $pointOfContactRole,
+                'shopEnvironment' => $shopEnvironment,
+            ]),
+        ]))->toArray()));
+
+        $this->assertEquals($organizationId, $this->statusManager->getOrganizationId());
+        $this->assertEquals($organizationName, $this->statusManager->getOrganizationName());
+        $this->assertEquals($pointOfContactRole, $this->statusManager->getPointOfContactRole());
+        $this->assertEquals($shopEnvironment, $this->statusManager->getShopEnvironment());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnNullOrgAndEnvironmentWhenStatusUnknown()
+    {
+        $this->configurationRepository->updateCachedShopStatus(null);
+
+        $this->assertNull($this->statusManager->getOrganizationId());
+        $this->assertNull($this->statusManager->getOrganizationName());
+        $this->assertNull($this->statusManager->getPointOfContactRole());
+        $this->assertNull($this->statusManager->getShopEnvironment());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldRoundTripOrgAndEnvironmentThroughCacheSerialization()
+    {
+        $values = [
+            'cloudShopId' => $this->faker->uuid,
+            'organizationId' => $this->faker->uuid,
+            'organizationName' => $this->faker->company,
+            'pointOfContactRole' => 'member',
+            'shopEnvironment' => 'Prod',
+        ];
+
+        $restored = new ShopStatus((new ShopStatus($values))->toArray());
+
+        $this->assertEquals($values['organizationId'], $restored->organizationId);
+        $this->assertEquals($values['organizationName'], $restored->organizationName);
+        $this->assertEquals($values['pointOfContactRole'], $restored->pointOfContactRole);
+        $this->assertEquals($values['shopEnvironment'], $restored->shopEnvironment);
+    }
 }


### PR DESCRIPTION
## Context

Module-side (`ps_accounts`) impacts of epics ACC-3398 (Add/Declare a Store to an Organization) and ACC-3170 (Organisation lifecycle), not covered by the other tickets of those epics. Three deliverables, split across two commits so the OAuth2/session change can be reviewed independently.

## Part 1 — Read org + environment, expose additively (commit `b1bcffc1`)
- `ShopStatus`: add flat **read-only** props `organizationId`, `organizationName`, `pointOfContactRole`, `shopEnvironment`.
- `StatusManager`: safe-defaulting getters (`try/catch UnknownStatusException → null`).
- `PsAccountsService`: thin delegating public getters — **additive only, no BC break**.

> ⚠️ **Provisional field names.** The accounts-api contract is **not frozen**; the four names must be reconciled with the API team against the real `/v1/shop-identities/{cloudShopId}/status` response before release.

## Part 2 — Allow POC before verification (commit `b1bcffc1`)
- Remove the `if (!$status->isVerified) return;` guard in `IdentifyContactHandler`. Verification is an identity/proof state, **not** an authorization gate; the accounts-api is the authority on whether the write is allowed (guard removal is unconditional — no `org_management_enabled` flag).

## Part 3 — Remove dead `shop.verified` scope machinery (commit `ed3c521b`)
- `shop.verified` is granted to verified shops but **enforced nowhere**: the accounts-api gates the point-of-contact endpoint on `aud` ownership only (oathkeeper `required_scope: []` / `allow`, no `@Scopes` guard), and the shop token is only ever presented to accounts-api.
- `getValidToken` now always requests an empty scope; removed the `InvalidScopeException` fallback, `fallbackRefresh()`, and unused imports; cleared the misleading `shop.verified` column in the README.
- **Behavior change:** verified shops no longer force a refresh to obtain the `scp` claim, and the `setIsVerified(false)` reconciliation is dropped — `ShopStatus` (`/status`, 30s TTL) remains the authoritative verification source. The permission system (ACC-3338) replaces scope-based authz.

## Testing
- Affected unit tests green: `IdentifyContactHandlerTest`, `StatusManagerTest`, `GetValidTokenTest` (24 tests, 64 assertions).
- New coverage: org/environment getters (cache round-trip + safe defaults); POC set on an unverified shop while cached `isVerified` stays false; scopeless token accepted for a verified shop.
- php-cs-fixer / header-stamp / PHPStan: no new findings from changed files (pre-existing issues in untouched files only).
- Full unit suite: no regressions (pre-existing failures confirmed identical on clean `main`).

## Review notes (⚠️ mandatory review — §5/§10)
- Parts 2 & 3 touch the OAuth2/session flow.
- **Residual BC surface:** `getShopToken()` returns the raw JWT to third-party modules; after Part 3 a verified shop's token no longer carries the `scp: shop.verified` claim — low risk, but a public-surface behavior change worth sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)