### PR TITLE
feat(status): add onBeforeStatusUpsert callback mechanism on StatusManager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ The module ships **one codebase** that must run from **PS 1.6 (PHP 5.6, no Symfo
 - **Never assume Symfony exists.** PS 1.6 has no Symfony container, router, or session. Core code goes through the module's own lightweight container, not the PS core container (see below).
 - **Branch on version explicitly, never implicitly.** Use `version_compare(_PS_VERSION_, 'X', '>=')`. Don't rely on a class/method merely existing unless you `method_exists()`/`class_exists()`-guard it.
 - **Test the edges, not just the middle.** A change that works on PS 8.1 can break PS 1.6 (syntax/Symfony) or PS 9 (upgrade/AST). Run the relevant platform presets.
+- **Catch both `\Exception` and `\Throwable`.** When wrapping code in a defensive `try/catch`, use two catch blocks — `catch (\Exception $e)` **then** `catch (\Throwable $e)`. On PHP 5.6 only `Exception` exists (the `Throwable` block is inert); on PHP 7+ `Error` types (TypeError, etc.) implement `Throwable` but **not** `Exception`, so a single `Exception` catch would let them escape. Established pattern — e.g. `src/Account/CommandHandler/UpdateBackOfficeUrlsHandler.php:42-46`, `src/Account/CommandHandler/RestoreIdentityHandler.php`, `src/Http/Controller/AbstractV2RestController.php`.
 
 ### Version detection — where & how
 

--- a/src/Account/CommandHandler/MultiShopHandler.php
+++ b/src/Account/CommandHandler/MultiShopHandler.php
@@ -66,6 +66,6 @@ abstract class MultiShopHandler
             return $this->shopContext->getMultiShopIds();
         }
         //return [\Shop::getContextShopID(true)];
-        return [\Shop::getContextShopID()];
+        return [(int) \Shop::getContextShopID()];
     }
 }

--- a/src/Account/StatusManager.php
+++ b/src/Account/StatusManager.php
@@ -78,11 +78,18 @@ class StatusManager
     private $onBeforeStatusUpsertListeners = [];
 
     /**
-     * Re-entrancy guard: a listener that calls getStatus() would re-trigger upsetCachedStatus.
+     * @var callable[]
+     */
+    private $onAfterStatusUpsertListeners = [];
+
+    /**
+     * Re-entrancy guard shared by both before/after dispatch: a listener that calls
+     * getStatus()/invalidateCache() would re-trigger upsetCachedStatus. The nested write
+     * still persists, but must not re-dispatch either hook.
      *
      * @var bool
      */
-    private $firingOnBeforeStatusUpsert = false;
+    private $firingStatusUpsert = false;
 
     /**
      * @param ShopSession $shopSession
@@ -112,12 +119,15 @@ class StatusManager
     }
 
     /**
-     * Register a callback invoked right before each status write.
+     * Register a callback invoked right before each status write, BEFORE persistence.
      *
      * Signature: function (ShopStatus|null $current, ShopStatus $new): void
      *
      * The callback is called on every upsert (including cache refreshes), so it is up to the
      * consumer to compare $current and $new and decide whether a meaningful change occurred.
+     * Note: it fires pre-persist, so it may fire for a write that subsequently fails, and the
+     * $new object it receives is the one about to be persisted (mutating it changes what is
+     * written). To react to a change that actually landed, prefer addOnAfterStatusUpsert().
      * A callback that throws is logged and swallowed: it must never break status/token persistence.
      *
      * @param callable $listener
@@ -127,6 +137,28 @@ class StatusManager
     public function addOnBeforeStatusUpsert($listener)
     {
         $this->onBeforeStatusUpsertListeners[] = $listener;
+
+        return $this;
+    }
+
+    /**
+     * Register a callback invoked right after each successful status write.
+     *
+     * Signature: function (ShopStatus|null $current, ShopStatus $new): void
+     *
+     * Unlike addOnBeforeStatusUpsert(), this fires only once $new has been durably persisted,
+     * so it is the correct hook to react to a status change that actually landed (mutating
+     * $new here is harmless). It is still called on every persisted upsert (including cache
+     * refreshes), so the consumer must diff $current and $new itself.
+     * A callback that throws is logged and swallowed: it must never break status/token persistence.
+     *
+     * @param callable $listener
+     *
+     * @return $this
+     */
+    public function addOnAfterStatusUpsert($listener)
+    {
+        $this->onAfterStatusUpsertListeners[] = $listener;
 
         return $this;
     }
@@ -439,46 +471,63 @@ class StatusManager
             $new = $cachedShopStatus;
         }
 
-        $this->fireOnBeforeStatusUpsert(
-            $current ? $current->shopStatus : null,
-            $new->shopStatus
-        );
+        $currentShopStatus = $current ? $current->shopStatus : null;
 
-        $this->setCachedStatus($new);
+        // re-entrant write from within a listener: persist, but do not re-dispatch either hook
+        if ($this->firingStatusUpsert) {
+            $this->setCachedStatus($new);
+
+            return;
+        }
+
+        $this->firingStatusUpsert = true;
+        try {
+            $this->fireStatusUpsert(
+                $this->onBeforeStatusUpsertListeners,
+                'onBeforeStatusUpsert',
+                $currentShopStatus,
+                $new->shopStatus
+            );
+
+            $this->setCachedStatus($new);
+
+            // after-hook fires only once the new status has been durably persisted
+            $this->fireStatusUpsert(
+                $this->onAfterStatusUpsertListeners,
+                'onAfterStatusUpsert',
+                $currentShopStatus,
+                $new->shopStatus
+            );
+        } finally {
+            $this->firingStatusUpsert = false;
+        }
     }
 
     /**
+     * @param callable[] $listeners
+     * @param string $label
      * @param ShopStatus|null $current
      * @param ShopStatus|null $new
      *
      * @return void
      */
-    private function fireOnBeforeStatusUpsert($current, $new)
+    private function fireStatusUpsert(array $listeners, $label, $current, $new)
     {
         // nothing to notify about when there is no new status
-        if (!($new instanceof ShopStatus) || empty($this->onBeforeStatusUpsertListeners)) {
-            return;
-        }
-        // avoid recursion if a listener reads/writes the status again
-        if ($this->firingOnBeforeStatusUpsert) {
+        if (!($new instanceof ShopStatus) || empty($listeners)) {
             return;
         }
 
-        $this->firingOnBeforeStatusUpsert = true;
-        try {
-            foreach ($this->onBeforeStatusUpsertListeners as $listener) {
-                try {
-                    call_user_func($listener, $current, $new);
-                } catch (\Exception $e) {
-                    // a third-party callback that fails must NEVER break status/token persistence
-                    Logger::getInstance()->error('onBeforeStatusUpsert listener error: ' . $e->getMessage());
-                } catch (\Throwable $e) {
-                    // PHP 7+: Error types (TypeError, etc.) implement Throwable but not Exception
-                    Logger::getInstance()->error('onBeforeStatusUpsert listener error: ' . $e->getMessage());
-                }
+        foreach ($listeners as $listener) {
+            try {
+                call_user_func($listener, $current, $new);
+            } catch (\Exception $e) {
+                // a third-party callback that fails must NEVER break status/token persistence
+                Logger::getInstance()->error($label . ' listener error: ' . $e->getMessage());
+            } catch (\Throwable $e) {
+                // PHP 7+: Error types (TypeError, etc.) implement Throwable but not Exception
+                Logger::getInstance()->error($label . ' listener error: ' . $e->getMessage());
             }
-        } finally {
-            $this->firingOnBeforeStatusUpsert = false;
         }
     }
 }

--- a/src/Account/StatusManager.php
+++ b/src/Account/StatusManager.php
@@ -73,6 +73,18 @@ class StatusManager
     private $throwException;
 
     /**
+     * @var callable[]
+     */
+    private $onBeforeStatusUpsertListeners = [];
+
+    /**
+     * Re-entrancy guard: a listener that calls getStatus() would re-trigger upsetCachedStatus.
+     *
+     * @var bool
+     */
+    private $firingOnBeforeStatusUpsert = false;
+
+    /**
      * @param ShopSession $shopSession
      * @param AccountsService $accountsService
      * @param ConfigurationRepository $repository
@@ -97,6 +109,26 @@ class StatusManager
         return array_merge($this->WithOriginAndSourceTrait_getDefaults(), [
             'throwException' => false,
         ]);
+    }
+
+    /**
+     * Register a callback invoked right before each status write.
+     *
+     * Signature: function (ShopStatus|null $current, ShopStatus $new): void
+     *
+     * The callback is called on every upsert (including cache refreshes), so it is up to the
+     * consumer to compare $current and $new and decide whether a meaningful change occurred.
+     * A callback that throws is logged and swallowed: it must never break status/token persistence.
+     *
+     * @param callable $listener
+     *
+     * @return $this
+     */
+    public function addOnBeforeStatusUpsert($listener)
+    {
+        $this->onBeforeStatusUpsertListeners[] = $listener;
+
+        return $this;
     }
 
     /**
@@ -397,12 +429,56 @@ class StatusManager
     protected function upsetCachedStatus(CachedShopStatus $cachedShopStatus, $all = false)
     {
         try {
-            $this->setCachedStatus(new CachedShopStatus(array_replace_recursive(
-                $this->getCachedStatus()->toArray(),
+            $current = $this->getCachedStatus();
+            $new = new CachedShopStatus(array_replace_recursive(
+                $current->toArray(),
                 $cachedShopStatus->toArray($all)
-           )));
+            ));
         } catch (UnknownStatusException $e) {
-            $this->setCachedStatus($cachedShopStatus);
+            $current = null; // first write / identity not created yet
+            $new = $cachedShopStatus;
+        }
+
+        $this->fireOnBeforeStatusUpsert(
+            ($current && $current->shopStatus instanceof ShopStatus) ? $current->shopStatus : null,
+            ($new->shopStatus instanceof ShopStatus) ? $new->shopStatus : null
+        );
+
+        $this->setCachedStatus($new);
+    }
+
+    /**
+     * @param ShopStatus|null $current
+     * @param ShopStatus|null $new
+     *
+     * @return void
+     */
+    private function fireOnBeforeStatusUpsert($current, $new)
+    {
+        // nothing to notify about when there is no new status
+        if (!($new instanceof ShopStatus) || empty($this->onBeforeStatusUpsertListeners)) {
+            return;
+        }
+        // avoid recursion if a listener reads/writes the status again
+        if ($this->firingOnBeforeStatusUpsert) {
+            return;
+        }
+
+        $this->firingOnBeforeStatusUpsert = true;
+        try {
+            foreach ($this->onBeforeStatusUpsertListeners as $listener) {
+                try {
+                    call_user_func($listener, $current, $new);
+                } catch (\Exception $e) {
+                    // a third-party callback that fails must NEVER break status/token persistence
+                    Logger::getInstance()->error('onBeforeStatusUpsert listener error: ' . $e->getMessage());
+                } catch (\Throwable $e) {
+                    // PHP 7+: Error types (TypeError, etc.) implement Throwable but not Exception
+                    Logger::getInstance()->error('onBeforeStatusUpsert listener error: ' . $e->getMessage());
+                }
+            }
+        } finally {
+            $this->firingOnBeforeStatusUpsert = false;
         }
     }
 }

--- a/src/Account/StatusManager.php
+++ b/src/Account/StatusManager.php
@@ -440,8 +440,8 @@ class StatusManager
         }
 
         $this->fireOnBeforeStatusUpsert(
-            ($current && $current->shopStatus instanceof ShopStatus) ? $current->shopStatus : null,
-            ($new->shopStatus instanceof ShopStatus) ? $new->shopStatus : null
+            $current ? $current->shopStatus : null,
+            $new->shopStatus
         );
 
         $this->setCachedStatus($new);

--- a/tests/src/Unit/Account/StatusManagerTest.php
+++ b/tests/src/Unit/Account/StatusManagerTest.php
@@ -244,4 +244,104 @@ class StatusManagerTest extends TestCase
         $this->assertFalse($cachedStatus->isVerified);
         $this->assertNull($cachedStatus->pointOfContactEmail);
     }
+
+    /**
+     * @test
+     */
+    public function itShouldCallOnBeforeStatusUpsertListenerWithCurrentAndNewStatus()
+    {
+        $this->configurationRepository->updateCachedShopStatus(json_encode((new CachedShopStatus([
+            'isValid' => true,
+            'updatedAt' => (new \DateTime())->format(\DateTime::ATOM),
+            'shopStatus' => new ShopStatus([
+                'cloudShopId' => $this->faker->uuid,
+                'isVerified' => false,
+            ]),
+        ]))->toArray()));
+
+        $received = [];
+        $this->statusManager->addOnBeforeStatusUpsert(function ($current, $new) use (&$received) {
+            $received[] = ['current' => $current, 'new' => $new];
+        });
+
+        $this->statusManager->setIsVerified(true);
+
+        $this->assertCount(1, $received);
+        $this->assertInstanceOf(ShopStatus::class, $received[0]['current']);
+        $this->assertInstanceOf(ShopStatus::class, $received[0]['new']);
+        $this->assertFalse($received[0]['current']->isVerified);
+        $this->assertTrue($received[0]['new']->isVerified);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldPassNullCurrentOnFirstStatusUpsert()
+    {
+        $this->configurationRepository->updateCachedShopStatus(null);
+
+        $received = [];
+        $this->statusManager->addOnBeforeStatusUpsert(function ($current, $new) use (&$received) {
+            $received[] = ['current' => $current, 'new' => $new];
+        });
+
+        $cloudShopId = $this->faker->uuid;
+        $this->statusManager->setCloudShopId($cloudShopId);
+
+        $this->assertCount(1, $received);
+        $this->assertNull($received[0]['current']);
+        $this->assertInstanceOf(ShopStatus::class, $received[0]['new']);
+        $this->assertEquals($cloudShopId, $received[0]['new']->cloudShopId);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotBreakUpsertWhenListenerThrows()
+    {
+        $this->configurationRepository->updateCachedShopStatus(json_encode((new CachedShopStatus([
+            'isValid' => true,
+            'updatedAt' => (new \DateTime())->format(\DateTime::ATOM),
+            'shopStatus' => new ShopStatus([
+                'cloudShopId' => $this->faker->uuid,
+                'isVerified' => false,
+            ]),
+        ]))->toArray()));
+
+        $this->statusManager->addOnBeforeStatusUpsert(function ($current, $new) {
+            throw new \RuntimeException('listener boom');
+        });
+
+        // must not propagate the listener exception
+        $this->statusManager->setIsVerified(true);
+
+        // and the status must still have been persisted
+        $this->assertTrue($this->statusManager->getStatus(true)->isVerified);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotRecurseWhenListenerTriggersAnotherUpsert()
+    {
+        $this->configurationRepository->updateCachedShopStatus(json_encode((new CachedShopStatus([
+            'isValid' => true,
+            'updatedAt' => (new \DateTime())->format(\DateTime::ATOM),
+            'shopStatus' => new ShopStatus([
+                'cloudShopId' => $this->faker->uuid,
+                'isVerified' => false,
+            ]),
+        ]))->toArray()));
+
+        $calls = 0;
+        $this->statusManager->addOnBeforeStatusUpsert(function ($current, $new) use (&$calls) {
+            ++$calls;
+            // re-entrant upsert: must be guarded, i.e. must not fire the listener again
+            $this->statusManager->invalidateCache();
+        });
+
+        $this->statusManager->setIsVerified(true);
+
+        $this->assertEquals(1, $calls);
+    }
 }

--- a/tests/src/Unit/Account/StatusManagerTest.php
+++ b/tests/src/Unit/Account/StatusManagerTest.php
@@ -344,4 +344,82 @@ class StatusManagerTest extends TestCase
 
         $this->assertEquals(1, $calls);
     }
+
+    /**
+     * @test
+     */
+    public function itShouldCallOnAfterStatusUpsertListenerWithCurrentAndNewStatus()
+    {
+        $this->configurationRepository->updateCachedShopStatus(json_encode((new CachedShopStatus([
+            'isValid' => true,
+            'updatedAt' => (new \DateTime())->format(\DateTime::ATOM),
+            'shopStatus' => new ShopStatus([
+                'cloudShopId' => $this->faker->uuid,
+                'isVerified' => false,
+            ]),
+        ]))->toArray()));
+
+        $received = [];
+        $this->statusManager->addOnAfterStatusUpsert(function ($current, $new) use (&$received) {
+            $received[] = ['current' => $current, 'new' => $new];
+        });
+
+        $this->statusManager->setIsVerified(true);
+
+        $this->assertCount(1, $received);
+        $this->assertInstanceOf(ShopStatus::class, $received[0]['current']);
+        $this->assertInstanceOf(ShopStatus::class, $received[0]['new']);
+        $this->assertFalse($received[0]['current']->isVerified);
+        $this->assertTrue($received[0]['new']->isVerified);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldFireOnAfterStatusUpsertOnlyAfterPersist()
+    {
+        $this->configurationRepository->updateCachedShopStatus(json_encode((new CachedShopStatus([
+            'isValid' => true,
+            'updatedAt' => (new \DateTime())->format(\DateTime::ATOM),
+            'shopStatus' => new ShopStatus([
+                'cloudShopId' => $this->faker->uuid,
+                'isVerified' => false,
+            ]),
+        ]))->toArray()));
+
+        $verifiedWhenListenerRan = null;
+        $this->statusManager->addOnAfterStatusUpsert(function ($current, $new) use (&$verifiedWhenListenerRan) {
+            // the new status must already be persisted by the time the after-hook fires
+            $verifiedWhenListenerRan = $this->statusManager->getStatus(true)->isVerified;
+        });
+
+        $this->statusManager->setIsVerified(true);
+
+        $this->assertTrue($verifiedWhenListenerRan);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotBreakUpsertWhenAfterListenerThrows()
+    {
+        $this->configurationRepository->updateCachedShopStatus(json_encode((new CachedShopStatus([
+            'isValid' => true,
+            'updatedAt' => (new \DateTime())->format(\DateTime::ATOM),
+            'shopStatus' => new ShopStatus([
+                'cloudShopId' => $this->faker->uuid,
+                'isVerified' => false,
+            ]),
+        ]))->toArray()));
+
+        $this->statusManager->addOnAfterStatusUpsert(function ($current, $new) {
+            throw new \RuntimeException('after listener boom');
+        });
+
+        // must not propagate the listener exception
+        $this->statusManager->setIsVerified(true);
+
+        // and the status must still have been persisted
+        $this->assertTrue($this->statusManager->getStatus(true)->isVerified);
+    }
 }


### PR DESCRIPTION
## What

Adds an in-process callback mechanism on `StatusManager` so consumers can **react to a shop-status change**.

- `StatusManager::addOnBeforeStatusUpsert(callable $listener)` registers a callback.
- Every status write funnels through `upsetCachedStatus()`; just before persisting, registered callbacks are invoked with **`(ShopStatus|null $current, ShopStatus $new)`**.
- `$current` is `null` on the first write (identity not created yet).

## Why

There was no way to hook into a status modification (e.g. trigger an action when the shop becomes verified). All status mutations already converge on the single `upsetCachedStatus()` choke-point, so that is the natural insertion point.

## How

- Extract the merged status into a local variable so the `(current, new)` pair is available before the write (previously the merge was inlined into the `setCachedStatus()` argument).
- **Exception-safe dispatch**: each callback is wrapped in a double `catch (\Exception)` + `catch (\Throwable)` (PHP 5.6/7+ compatible, pattern already used in the codebase). A failing third-party callback is logged and swallowed — it must **never** break status/token persistence.
- **Re-entrancy guard**: a listener that reads/writes the status again (`getStatus()`, `invalidateCache()`, …) does not recurse.
- Fires on **every** upsert (including the ~30s cache refresh), so consumers must diff `$current`/`$new` themselves — the mechanism stays intentionally dumb, matching the requested "current + new status" semantics.

Also documents the `\Exception` + `\Throwable` double-catch convention in `CLAUDE.md` (§4 golden rules).

### Usage
```php
/** @var StatusManager $sm */
$sm = $module->getService(StatusManager::class);
$sm->addOnBeforeStatusUpsert(function ($current, $new) {
    $was = $current ? $current->isVerified : false;
    if (!$was && $new->isVerified) {
        // the shop just became verified -> react
    }
});
```

## Tests

Added to `tests/src/Unit/Account/StatusManagerTest.php`:
- listener receives the correct `(current, new)` pair on change;
- `$current` is `null` on the first upsert;
- a throwing listener does not break the upsert (status still persisted);
- no recursion when a listener triggers another upsert.

`StatusManagerTest` → **OK (9 tests, 22 assertions)**, ~99% line coverage.

## Reviewer notes

- ⚠️ `StatusManager` is **auth-adjacent** (drives status/verification persistence) — review recommended.
- PHP 5.6 compat respected (no typed props, short arrays, `finally`, `call_user_func`, no implicit-nullable hints). Local runtimes were 7.4/8.3 only; the 5.6 syntax lint runs in CI.
- `phpstan` could not run locally (binary absent from the container) — relies on CI.
- No ticket id was available at creation time — please prefix the title with `[ACC-xxxx]` before merge per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)