### PR TITLE
[ACC-3504] fix(build): use `pnpm -C ./_dev run build` for the front build

### DIFF
--- a/.github/workflows/build-release-publish.yml
+++ b/.github/workflows/build-release-publish.yml
@@ -48,7 +48,7 @@ jobs:
         run: make php-scoper
 
       - name: Build front
-        run: pnpm --filter ./_dev build
+        run: pnpm -C ./_dev run build
 
       - name: Clean-up project 🧹
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,10 @@ make phpstan              # Static analysis (runs in Docker)
 make build-front
 # Equivalent to:
 pnpm --filter ./_dev install --frozen-lockfile --ignore-scripts
-pnpm --filter ./_dev build
+pnpm -C ./_dev run build
+# Do NOT use `pnpm --filter ./_dev build` from the repo root: since pnpm 11 the
+# dependency-freshness check (verify-deps-before-run) runs `pnpm install` in the
+# CWD first, and the repo root has no package.json → ERR_PNPM_NO_PKG_MANIFEST.
 
 # Bundling
 make bundle          # Full bundle: php-scoper + config + front → ps_accounts.zip

--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ define build_front
 	rm -f ./views/js/app.*.js
 	rm -f ./views/css/app.*.css
 	pnpm --filter ./_dev install --frozen-lockfile --ignore-scripts
-	pnpm --filter ./_dev build
+	pnpm -C ./_dev run build
 endef
 
 build-front:


### PR DESCRIPTION
Fixes [ACC-3504](https://prestashop-jira.atlassian.net/browse/ACC-3504).

# What problem this PR is trying to solve?

`make build-front` — and therefore every `make bundle*` target — fails on Node **lts/jod (v22.23.2)**:

```
[WARN] Skipping check.
[ERR_PNPM_NO_PKG_MANIFEST] No package.json found in /…/ps_accounts
[ERROR] Command failed with exit code 1: node …/pnpm.mjs install
    at runDepsStatusCheck (…/pnpm@11.20.0/…/pnpm.mjs:254302:7)
```

**Cause:** pnpm 11 flipped the default of `verify-deps-before-run` from `false` to `"install"`. Before running a *script*, pnpm now shells out to `pnpm install` **in the CWD**. `pnpm --filter ./_dev build` runs from the repo root, which has no `package.json` and no `pnpm-workspace.yaml`, so that nested install dies.

This is a **pnpm 11-only** regression — pnpm 9.15.9 and 10.34.5 both run the old command fine. That's why CI is still green: it pins `version: 10`. The identical latent call sat at `build-release-publish.yml:51` and would have fired on the next pnpm bump.

It surfaced now because Node v22.4.0 (the previous local default) **cannot run pnpm 11 at all** (`requires >= 22.13`). Moving to lts/jod — which matches the repo's tracked `.nvmrc` (`v22`) — unmasked it.

# How can anyone reproduce the issue?

```bash
source ~/.nvm/nvm.sh && nvm use     # reads ./.nvmrc → v22.23.2
pnpm --version                      # 11.x
make build-front                    # ERR_PNPM_NO_PKG_MANIFEST on main
```

# Which version of the module is impacted?

All versions — this is build tooling only, no shipped module code changes. Nothing under `src/`, `sql/`, `upgrade/` or any restricted area is touched, so there is no PS 1.6/PHP 5.6 or PS 9 upgrade-path risk.

# Description of this PR changes

`pnpm --filter ./_dev build` → `pnpm -C ./_dev run build` at both call sites, plus the docs:

| File | Line |
|---|---|
| `Makefile` (`build_front` macro) | 318 |
| `.github/workflows/build-release-publish.yml` | 51 |
| `CLAUDE.md` | 215-217 (+ a note on why `--filter` fails there) |

`-C ./_dev` puts pnpm's CWD inside a directory that *has* a `package.json`, so the pre-run check resolves instead of dying.

### ⚠️ Reviewer note — the install line stays on `--filter` on purpose

`Makefile:317` is deliberately **not** harmonised with line 318. Verified 4/4 in a controlled A/B (delete `_dev/node_modules/vite` + its virtual-store entry, then reinstall):

- `--filter … install` restores it **every time**
- `-C … install --frozen-lockfile` takes the *"Lockfile is up to date … Already up to date"* fast path, **never** restores it, and the build then dies with `Cannot find module …/vite/bin/vite.js`

The `--filter` form is what makes `make build-front` self-healing against a half-broken `node_modules`. Only the script-running line was ever broken.

### Deliberately out of scope

- **`packageManager` in `_dev/package.json`** — disproven end-to-end: pnpm reads it from the CWD's project root, so `make build-front` still failed with the field applied. Inert in CI (`action-setup` `version:` wins), and pinning pnpm 10 against a pnpm-11 `node_modules` hard-fails with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. (Distinct from ACC-3497, which targets the `accounts` repo.)
- **`.nvmrc`** — already tracked, already `v22` → v22.23.2, which runs pnpm 11 correctly.
- **CI `version: 10` / `node-version: 20`** — green today; bumping pnpm to 11 forces Node to 22 in the same commit, so it belongs in its own PR.
- **`caniuse-lite` staleness warning** — output verified byte-identical; refreshing costs a ~3,600-line lockfile diff under pnpm 11.

## Verification

```bash
source ~/.nvm/nvm.sh && nvm use
rm -rf _dev/node_modules views/js/login*.js views/css/login*.css views/js/notifications.js
make build-front                       # rc=0
ls -l views/js/login.js views/css/login.css views/js/notifications.js
# 43832 / 7753 / 855 bytes

make build-front && make build-front   # idempotent, rc=0 both times

# self-healing guard — regresses if line 317 is also changed
rm -rf _dev/node_modules/vite _dev/node_modules/.pnpm/vite@6.1.0*
make build-front                       # rc=0, vite restored

git diff --stat _dev/pnpm-lock.yaml    # empty
```

All green on Node **22.23.2 / 24.19.0 / 26.7.0**, with artifacts byte-identical across all three *and* identical to what the pre-change build produced.

The workflow change (`build-release-publish.yml`) can't be dry-run — worth validating on a prerelease tag that the three artifacts land non-empty in the uploaded artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ACC-3504]: https://prestashop-jira.atlassian.net/browse/ACC-3504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ