### PR TITLE
fix(e2e): resolve the latest module release in TNR V8 instead of pinning a tag

### DIFF
--- a/e2e/scripts/resolve-module-version.sh
+++ b/e2e/scripts/resolve-module-version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Résout la version du module ps_accounts à installer dans les TNR.
+#
+# Une seule ligne de version du module est supportée : on prend donc la
+# dernière release publiée, sans épingler de tag. Un pin figé finit par
+# désigner un zip qui ne sait plus s'enrôler quand l'infra évolue (cf. #655).
+#
+# Override : exporter PS_ACCOUNTS_VERSION avant l'appel (utile en local pour
+# rejouer une TNR sur une version précise).
+
+resolve_module_version() {
+  local repo="PrestaShopCorp/ps_accounts"
+
+  if [ -z "${PS_ACCOUNTS_VERSION:-}" ]; then
+    # On suit la redirection de /releases/latest plutôt que d'interroger
+    # l'API : pas de token requis et pas de rate limit à 60 req/h/IP.
+    PS_ACCOUNTS_VERSION="$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+      "https://github.com/${repo}/releases/latest" | sed 's#.*/tag/##')"
+  fi
+
+  if ! echo "${PS_ACCOUNTS_VERSION}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+    echo "[ps_accounts] impossible de résoudre la dernière release (obtenu: '${PS_ACCOUNTS_VERSION}')" >&2
+    return 1
+  fi
+
+  export PS_ACCOUNTS_VERSION
+  echo "[ps_accounts] version cible : ${PS_ACCOUNTS_VERSION}"
+}

--- a/e2e/scripts/run-tnr-multistore-v8.sh
+++ b/e2e/scripts/run-tnr-multistore-v8.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-export PS_ACCOUNTS_VERSION="v8.0.17"
+source "$(dirname "$0")/resolve-module-version.sh"
+resolve_module_version
 
 if [ -n "${1:-}" ]; then
   SHOP_VERSIONS=("$1")

--- a/e2e/scripts/run-tnr-multistore-v8.sh
+++ b/e2e/scripts/run-tnr-multistore-v8.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-export PS_ACCOUNTS_VERSION="v8.0.10"
+export PS_ACCOUNTS_VERSION="v8.0.17"
 
 if [ -n "${1:-}" ]; then
   SHOP_VERSIONS=("$1")

--- a/e2e/scripts/run-tnr-v8.sh
+++ b/e2e/scripts/run-tnr-v8.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-export PS_ACCOUNTS_VERSION="v8.0.17"
+source "$(dirname "$0")/resolve-module-version.sh"
+resolve_module_version
 
 if [ -n "${1:-}" ]; then
   SHOP_VERSIONS=("$1")

--- a/e2e/scripts/run-tnr-v8.sh
+++ b/e2e/scripts/run-tnr-v8.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-export PS_ACCOUNTS_VERSION="v8.0.10"
+export PS_ACCOUNTS_VERSION="v8.0.17"
 
 if [ -n "${1:-}" ]; then
   SHOP_VERSIONS=("$1")


### PR DESCRIPTION
## Problème

`run-tnr-v8.sh` et `run-tnr-multistore-v8.sh` hardcodaient `export PS_ACCOUNTS_VERSION="v8.0.10"`. v8.0.10 (janvier 2026) est antérieur à #634 (avril 2026), qui a migré les URLs préprod vers `*.preproduction.prestashop.com`. L'ancienne infra (`oauth-preprod.prestashop.com`, `*.distribution-preprod.prestashop.net`) n'existe plus → l'enrôlement du shop échouait : pas de client OAuth2, clés `PS_ACCOUNTS_*` absentes de `ps_configuration`, `shopLinked=false`, puis timeouts 120 s en cascade sur shop_verification / point_of_contact / multistore.

Le [run 33060778867](https://github.com/PrestaShopCorp/ps_accounts/actions/runs/33060778867) comptait **45 échecs / 21 succès** (15 échecs identiques sur chacune des 3 versions PS), soit une TNR rouge depuis quatre mois.

## Correctif

Comme une seule ligne de version du module est supportée, les scripts V8 **résolvent la dernière release publiée à l'exécution** au lieu d'épingler un tag — un pin figé finit toujours par désigner un zip incapable de s'enrôler quand l'infra évolue. La résolution suit la redirection de `/releases/latest` plutôt que l'API : pas de token requis, pas de rate limit à 60 req/h/IP. Exporter `PS_ACCOUNTS_VERSION` continue de forcer une version (rejeu local).

Les scripts V7 gardent leur pin : cette ligne n'est plus publiée (dernière release v7.2.2, juillet 2025).

## Validation

[Run 33071519930](https://github.com/PrestaShopCorp/ps_accounts/actions/runs/33071519930) (premier commit, pin v8.0.17) → **66/66 passés, 0 échec**, les 3 jobs confirmant `imageoff v8.0.17`. À rejouer sur la résolution dynamique.

## Hors périmètre

- `dbRequest.ts:47` : `expect(results).not.toBeNull()` ne protège rien (un SELECT vide renvoie `[]`) → les échecs remontent en `TypeError` illisible au lieu de « clé absente ».
- Timeouts 120 s sur éléments absents → ~18 min de CI gaspillées ; préférer `toBeVisible({timeout: 10_000})`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)