### PR TITLE
feat(e2e): add a PR workflow validating the module built from the branch

### DIFF
--- a/.github/workflows/e2e-accounts-pr.yml
+++ b/.github/workflows/e2e-accounts-pr.yml
@@ -5,6 +5,9 @@ on:
     types: [labeled, synchronize, reopened]
   workflow_dispatch:
 
+env:
+  IMAGE_PREFIX: ghcr.io/prestashopcorp/
+
 # Le compte de test et le tunnel sont des ressources UNIQUES et partagées :
 # jamais deux runs e2e en même temps, toutes PR confondues.
 concurrency:
@@ -15,6 +18,7 @@ jobs:
   build-module:
     name: Build the PR module zip
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # PR de fork : pas d'accès aux secrets. On ne tente pas.
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -64,19 +68,49 @@ jobs:
     name: Run Account tests (PR build)
     needs: build-module
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v5
+
+      # Sans ça, le téléchargement des navigateurs Playwright se bloque
+      # indéfiniment sur les runners (cf. le job setup du TNR V8).
+      - name: Tune kernel buffers
+        run: |
+          sudo sysctl -w net.core.rmem_max=2500000
+          sudo sysctl -w net.core.rmem_default=2500000
+
+      # Mêmes clés que le TNR V8 : on réutilise ses entrées de cache.
+      - name: Cache node_modules
+        id: cache-node
+        uses: actions/cache@v5
+        with:
+          path: ./e2e/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+
+      - name: Cache Playwright browsers
+        id: cache-pw
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-browsers-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+          restore-keys: |
+            pw-browsers-${{ runner.os }}-
 
       - uses: actions/setup-node@v5
         with:
           node-version: "node"
 
       - name: Install dependencies
+        if: steps.cache-node.outputs.cache-hit != 'true'
         working-directory: ./e2e
         run: npm ci
 
       - name: Install Playwright Browsers
+        if: steps.cache-pw.outputs.cache-hit != 'true'
         working-directory: ./e2e
+        timeout-minutes: 10
         run: npx playwright install chromium
 
       # C'est ici que le workflow diverge du TNR : le module testé est celui
@@ -100,6 +134,13 @@ jobs:
           echo "QA_USER_AGENT=${{ secrets.QA_USER_AGENT }}" >> .env
           echo "ACCOUNT_EMAIL=${{ secrets.ACCOUNT_EMAIL }}" >> .env
           echo "ACCOUNT_PASSWORD=${{ secrets.ACCOUNT_PASSWORD }}" >> .env
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: prestashopcorp
+          password: ${{ secrets.DOWNLOADER_TOKEN }}
 
       - name: Generate .env in e2e-env
         working-directory: ./e2e-env

--- a/.github/workflows/e2e-accounts-pr.yml
+++ b/.github/workflows/e2e-accounts-pr.yml
@@ -19,6 +19,8 @@ jobs:
     name: Build the PR module zip
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      version: ${{ steps.module_version.outputs.version }}
     # PR de fork : pas d'accès aux secrets. On ne tente pas.
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -57,6 +59,14 @@ jobs:
         run: |
           cp ./config.dist.php ./config.php   # gitignoré, absent d'un checkout frais
           sh ./scripts/bundle-module.sh 'ps_accounts.zip' 'preprod'
+
+      # Les tests comparent la version en base à PS_ACCOUNTS_VERSION. Ici le
+      # module ne vient pas d'une release : la référence est le config.xml
+      # de la PR.
+      - name: Read the built module version
+        id: module_version
+        run: |
+          echo "version=v$(sed -n 's/.*<version><!\[CDATA\[\(.*\)\]\]><\/version>.*/\1/p' config.xml)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -158,6 +168,8 @@ jobs:
       # échec de build du shop doit casser le job.
       - name: Run test
         working-directory: ./e2e
+        env:
+          PS_ACCOUNTS_VERSION: ${{ needs.build-module.outputs.version }}
         run: |
           npm run tnr-v8 -- 8.2.0-8.1
           npm run tnr-multistore-v8 -- 8.2.0-8.1

--- a/.github/workflows/e2e-accounts-pr.yml
+++ b/.github/workflows/e2e-accounts-pr.yml
@@ -174,50 +174,50 @@ jobs:
           npm run tnr-v8 -- 8.2.0-8.1
           npm run tnr-multistore-v8 -- 8.2.0-8.1
 
-      - name: Generate Allure Report
-        if: always()
-        working-directory: ./e2e
-        run: |
-          cp -r allure-results-8.2.0-8.1/. allure-results/ 2>/dev/null || true
-          npm run generate-allure-report
-
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: allure-report-pr
-          path: ./e2e/allure-report
-
-      # La gate. Le rapport reste le canal d'analyse ; la CI ne fait que
-      # traduire ses compteurs en statut de check.
+      # La gate. Pas de rapport ni de notification : le statut du check et
+      # le step summary suffisent.
       - name: Fail on test failures
         if: always()
         shell: bash
         run: |
           set -euo pipefail
-          SUMMARY="e2e/allure-report/widgets/summary.json"
-          if [ ! -f "$SUMMARY" ]; then
-            echo "::error::rapport Allure introuvable — les tests n'ont pas produit de résultat"
+
+          # Les résultats bruts d'Allure : un fichier par test, champ .status.
+          # Aucun rapport à générer pour les lire. On les concatène en un seul
+          # flux plutôt que de passer N chemins en arguments.
+          results=$(find ./e2e -maxdepth 2 -path '*allure-results*' -name '*-result.json' -exec cat {} +)
+          total=$(printf '%s' "$results" | jq -s 'length')
+
+          if [ "$total" -eq 0 ]; then
+            echo "::error::aucun test exécuté — les tests n'ont produit aucun résultat"
+            echo "### TNR V8 — build de la PR : aucun test exécuté" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-          read -r passed failed broken skipped total < <(jq -r '.statistic |
-            "\(.passed // 0) \(.failed // 0) \(.broken // 0) \(.skipped // 0) \(.total // 0)"' "$SUMMARY")
+
+          ko=$(printf '%s' "$results" | jq -s '[.[] | select(.status == "failed" or .status == "broken")] | length')
+          ok=$(( total - ko ))
 
           {
             echo "### TNR V8 — build de la PR (PS 8.2.0-8.1)"
             echo ""
-            echo "| passed | failed | broken | skipped | total |"
-            echo "|---:|---:|---:|---:|---:|"
-            echo "| $passed | $failed | $broken | $skipped | $total |"
+            echo "$ok/$total tests OK"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          # `total == 0` est volontaire : sans ça, un run où rien n'a tourné
-          # passerait au vert.
-          if [ "$total" -eq 0 ]; then
-            echo "::error::aucun test exécuté"
+          if [ "$ko" -gt 0 ]; then
+            failures=$(printf '%s' "$results" | jq -r 'select(.status == "failed" or .status == "broken")
+              | "\(.fullName // .name) — \((.statusDetails.message // "") | split("\n")[0])"')
+
+            {
+              echo ""
+              echo "#### Échecs"
+              echo ""
+              printf '%s\n' "$failures" | sed 's/^/- /'
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            printf '%s\n' "$failures" | sed 's/^/::error::/'
+
+            echo "::error::$ko échec(s) sur $total tests"
             exit 1
           fi
-          if [ "$failed" -gt 0 ] || [ "$broken" -gt 0 ]; then
-            echo "::error::$failed échec(s), $broken cassé(s) sur $total tests"
-            exit 1
-          fi
-          echo "$passed/$total tests OK"
+
+          echo "$ok/$total tests OK"

--- a/.github/workflows/e2e-accounts-pr.yml
+++ b/.github/workflows/e2e-accounts-pr.yml
@@ -1,0 +1,170 @@
+name: e2e Accounts PR
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+  workflow_dispatch:
+
+# Le compte de test et le tunnel sont des ressources UNIQUES et partagées :
+# jamais deux runs e2e en même temps, toutes PR confondues.
+concurrency:
+  group: e2e-shared-account
+  cancel-in-progress: false
+
+jobs:
+  build-module:
+    name: Build the PR module zip
+    runs-on: ubuntu-latest
+    # PR de fork : pas d'accès aux secrets. On ne tente pas.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'e2e'))
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: |
+            - cwd: _dev/
+              package_json_file: _dev/package.json
+              args: [--frozen-lockfile, --ignore-scripts]
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_RO }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@prestashopcorp'
+          cache: 'pnpm'
+          cache-dependency-path: '_dev/pnpm-lock.yaml'
+
+      # Même recette que build-release-publish.yml (`make bundle-preprod` est
+      # cassé : la cible `config.php.preprod` n'existe pas dans le Makefile).
+      - name: Scoped dependencies
+        run: make php-scoper
+
+      - name: Build front
+        run: pnpm -C ./_dev run build
+
+      - name: Bundle the preprod zip
+        run: |
+          cp ./config.dist.php ./config.php   # gitignoré, absent d'un checkout frais
+          sh ./scripts/bundle-module.sh 'ps_accounts.zip' 'preprod'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-module-zip
+          path: dist/ps_accounts.zip
+          retention-days: 3
+
+  run-test:
+    name: Run Account tests (PR build)
+    needs: build-module
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "node"
+
+      - name: Install dependencies
+        working-directory: ./e2e
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        working-directory: ./e2e
+        run: npx playwright install chromium
+
+      # C'est ici que le workflow diverge du TNR : le module testé est celui
+      # de la PR, pas une release publiée.
+      - name: Download the PR module zip
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-module-zip
+          path: ./e2e-env/local-module
+
+      - name: Generate .env in e2e
+        working-directory: ./e2e
+        run: |
+          echo "BASE_URL=${{ secrets.BASE_URL }}" >> .env
+          echo "BASE_URL_FO=${{ secrets.BASE_URL_FO }}" >> .env
+          echo "ADMIN_EMAIL=${{ secrets.ADMIN_EMAIL }}" >> .env
+          echo "ADMIN_PASSWORD=${{ secrets.ADMIN_PASSWORD }}" >> .env
+          echo "OAUTH2URL=${{ secrets.OAUTH2URL }}" >> .env
+          echo "ACCOUNTSAPIURL=${{ secrets.ACCOUNTSAPIURL }}" >> .env
+          echo "ACCOUNTSUIURL=${{ secrets.ACCOUNTSUIURL }}" >> .env
+          echo "QA_USER_AGENT=${{ secrets.QA_USER_AGENT }}" >> .env
+          echo "ACCOUNT_EMAIL=${{ secrets.ACCOUNT_EMAIL }}" >> .env
+          echo "ACCOUNT_PASSWORD=${{ secrets.ACCOUNT_PASSWORD }}" >> .env
+
+      - name: Generate .env in e2e-env
+        working-directory: ./e2e-env
+        run: |
+          echo "ACCOUNT_TAG=${{ secrets.ACCOUNT_TAG }}" >> .env
+          echo "TUNNEL_SECRET=${{ secrets.TUNNEL_SECRET }}" >> .env
+          echo "TUNNEL_ID=${{ secrets.TUNNEL_ID }}" >> .env
+          echo "PS_DOMAIN=${{ secrets.PS_DOMAIN }}" >> .env
+          echo "DOMAIN=${{ secrets.DOMAIN }}" >> .env
+          echo "DOWNLOADER_TOKEN=${{ secrets.DOWNLOADER_TOKEN }}" >> .env
+          echo "PS_VERSION=${{ secrets.PS_VERSION }}" >> .env
+
+      # Une seule version PS sur PR (~12 min). La matrice complète reste au
+      # TNR en workflow_dispatch / nightly. Pas de continue-on-error : un
+      # échec de build du shop doit casser le job.
+      - name: Run test
+        working-directory: ./e2e
+        run: |
+          npm run tnr-v8 -- 8.2.0-8.1
+          npm run tnr-multistore-v8 -- 8.2.0-8.1
+
+      - name: Generate Allure Report
+        if: always()
+        working-directory: ./e2e
+        run: |
+          cp -r allure-results-8.2.0-8.1/. allure-results/ 2>/dev/null || true
+          npm run generate-allure-report
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: allure-report-pr
+          path: ./e2e/allure-report
+
+      # La gate. Le rapport reste le canal d'analyse ; la CI ne fait que
+      # traduire ses compteurs en statut de check.
+      - name: Fail on test failures
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          SUMMARY="e2e/allure-report/widgets/summary.json"
+          if [ ! -f "$SUMMARY" ]; then
+            echo "::error::rapport Allure introuvable — les tests n'ont pas produit de résultat"
+            exit 1
+          fi
+          read -r passed failed broken skipped total < <(jq -r '.statistic |
+            "\(.passed // 0) \(.failed // 0) \(.broken // 0) \(.skipped // 0) \(.total // 0)"' "$SUMMARY")
+
+          {
+            echo "### TNR V8 — build de la PR (PS 8.2.0-8.1)"
+            echo ""
+            echo "| passed | failed | broken | skipped | total |"
+            echo "|---:|---:|---:|---:|---:|"
+            echo "| $passed | $failed | $broken | $skipped | $total |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # `total == 0` est volontaire : sans ça, un run où rien n'a tourné
+          # passerait au vert.
+          if [ "$total" -eq 0 ]; then
+            echo "::error::aucun test exécuté"
+            exit 1
+          fi
+          if [ "$failed" -gt 0 ] || [ "$broken" -gt 0 ]; then
+            echo "::error::$failed échec(s), $broken cassé(s) sur $total tests"
+            exit 1
+          fi
+          echo "$passed/$total tests OK"

--- a/e2e-env/docker-compose.yml
+++ b/e2e-env/docker-compose.yml
@@ -116,6 +116,9 @@ services:
       - ./scripts-imageoff/pre-install-scripts:/tmp/pre-install-scripts
       - ./scripts-imageoff/post-install-scripts:/tmp/post-install-scripts
       - ./scripts-imageoff/install-ps_accounts.sh:/install-ps_accounts.sh
+      # Flux PR : zip construit depuis la branche. Absent en flux TNR, le
+      # bind mount est alors un dossier vide et l'install retombe sur wget.
+      - ./local-module:/local-module:ro
     labels:
       - traefik.enable=true
       - traefik.http.routers.shop1.rule=${SHOP1_TRAEFIK_RULE}
@@ -188,6 +191,9 @@ services:
       - ./scripts-imageoff/pre-install-scripts:/tmp/pre-install-scripts
       - ./scripts-imageoff/post-install-scripts:/tmp/post-install-scripts
       - ./scripts-imageoff/install-ps_accounts.sh:/install-ps_accounts.sh
+      # Flux PR : zip construit depuis la branche. Absent en flux TNR, le
+      # bind mount est alors un dossier vide et l'install retombe sur wget.
+      - ./local-module:/local-module:ro
     labels:
       - traefik.enable=true
       - traefik.http.routers.shop2.rule=${SHOP2_TRAEFIK_RULE}

--- a/e2e-env/local-module/.gitignore
+++ b/e2e-env/local-module/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/e2e-env/scripts-imageoff/install-ps_accounts.sh
+++ b/e2e-env/scripts-imageoff/install-ps_accounts.sh
@@ -1,14 +1,16 @@
 set -eu
 cd "$(dirname $0)" || exit 1
 
-# Download and install the module's zip
+# Le zip du module : celui construit localement s'il est monté (flux PR,
+# on teste le code de la branche), sinon la release publiée (flux TNR).
+LOCAL_ZIP="/local-module/ps_accounts.zip"
 GITHUB_REPOSITORY="PrestaShopCorp/ps_accounts"
-TARGET_VERSION=${PS_ACCOUNTS_VERSION}
+TARGET_VERSION=${PS_ACCOUNTS_VERSION:-}
 
-if echo "$PS_ACCOUNTS_VERSION" | grep -q "beta"; then
-    CLEANED_VERSION="${PS_ACCOUNTS_VERSION%-beta*}" 
+if echo "$TARGET_VERSION" | grep -q "beta"; then
+    CLEANED_VERSION="${TARGET_VERSION%-beta*}"
 else
-    CLEANED_VERSION="${PS_ACCOUNTS_VERSION}" 
+    CLEANED_VERSION="${TARGET_VERSION}"
 fi
 
 TARGET_ASSET="ps_accounts_preprod-${CLEANED_VERSION#v}.zip"
@@ -17,10 +19,15 @@ TARGET_ASSET="ps_accounts_preprod-${CLEANED_VERSION#v}.zip"
 PS_ROOT="/var/www/html/${PHYSICAL_URI:-}"
 CHOWN_USER="www-data:www-data"
 
-# Download ps_accounts module
-echo "* [ps_accounts] downloading..."
-echo "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TARGET_VERSION}/${TARGET_ASSET}"
-wget -q -O /tmp/ps_accounts.zip "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TARGET_VERSION}/${TARGET_ASSET}"
+# Fetch ps_accounts module
+if [ -f "$LOCAL_ZIP" ]; then
+  echo "* [ps_accounts] using locally built zip [${LOCAL_ZIP}]"
+  cp "$LOCAL_ZIP" /tmp/ps_accounts.zip
+else
+  echo "* [ps_accounts] downloading..."
+  echo "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TARGET_VERSION}/${TARGET_ASSET}"
+  wget -q -O /tmp/ps_accounts.zip "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TARGET_VERSION}/${TARGET_ASSET}"
+fi
 
 # Unzip ps_accounts module
 echo "* [ps_accounts] unzipping..."


### PR DESCRIPTION
Les TNR installent une **release publiée** : elles n'exercent jamais le code en revue, et ne remontent que via le rapport Allure. Ce workflow complémentaire construit le module **depuis la PR** et traduit les compteurs du rapport en statut de check CI.

- `build-module` : reprend la recette de `build-release-publish.yml` (php-scoper, build front, `bundle-module.sh preprod`). `make bundle-preprod` est inutilisable — son prérequis `config.php.preprod` n'existe pas dans le Makefile.
- `run-test` : installe ce zip au lieu d'une release, sur PS 8.2.0-8.1 seulement pour tenir en ~12 min. La matrice complète reste au TNR en `workflow_dispatch`.
- La gate échoue si `failed + broken > 0`, **et aussi si `total == 0`** — sans ça un run où rien n'a tourné passerait au vert. Les compteurs sont écrits dans le step summary ; le rapport Allure reste le canal d'analyse.
- `install-ps_accounts.sh` devient *local-first* : zip monté s'il est présent, sinon `wget` de la release **à l'identique** → le flux TNR n'est pas affecté (sans zip, le bind mount est un dossier vide et le test `-f` échoue).

**Déclenchement opt-in par label `e2e`** : le compte de test et le tunnel sont des ressources uniques partagées, et un groupe `concurrency` ne met qu'**un seul** run en attente — un trigger systématique affamerait les PR concurrentes. Les PR de forks sont exclues : pas d'accès aux secrets, et `pull_request_target` est exclu sur un repo public.

⚠️ Le label `e2e` n'existe pas encore dans le repo, donc ce workflow ne peut pas se déclencher tel quel : il faut créer le label (ou changer la condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)