### PR TITLE
chore(_dev): dead config references and stale toolchain docs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -145,7 +145,7 @@ jobs:
             - `src/Http/` — client HTTP interne (curl uniquement)
             - `sql/` — scripts de migration SQL
             - `upgrade/` — scripts d'upgrade du module
-            - `_dev/apps/` — frontend TypeScript/Vue 3 (compile dans views/)
+            - `_dev/apps/` — frontend TypeScript, builds lib Vite (compile dans views/)
             - `config/` — definitions YAML pour l'integration PrestaShop core
 
             Mode : ${{ steps.ctx.outputs.is_re_review == 'true' && 'RE-REVIEW' || 'REVIEW INITIALE' }}

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,8 @@ views/files/*
 /views/css/chunk-vendors.css
 /views/favicon.ico
 /views/index.html
-./_dev/.npmrc
+_dev/.npmrc2
+_dev/.npmrc.local
 
 # Log files
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 **Squad:** Squad Account
 **Functional domain:** Token generation, OAuth2 authentication flow, shop identification/verification, synchronization with PrestaShop Cloud
-**Main stack:** PHP 5.6–8.3 / Node.js / TypeScript / Vue 3 / Vite / PrestaShop 1.6–9.x
+**Main stack:** PHP 5.6–8.3 / Node.js 24 / TypeScript / Vite / PrestaShop 1.6–9.x
 **Architecture pattern:** CQRS in `src/Account/` · legacy controllers in `controllers/`
 
 ---
@@ -33,7 +33,7 @@
 | `templates/`                        | Twig templates                                                       |
 | `upgrade/`                          | Module upgrade scripts                                               |
 | `controllers/`                      | Legacy controllers                                                   |
-| `_dev/apps/`                        | TypeScript/Vue frontend (compiled to `views/`)                       |
+| `_dev/apps/`                        | TypeScript frontend, Vite lib builds (compiled to `views/`)          |
 | `config/`                           | YAML definitions for PrestaShop core integration (routing, services) |
 | `tests/src/Unit/`                   | Unit tests                                                           |
 | `tests/src/Feature/`                | Feature / integration tests                                          |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 PHP = $(shell which php 2> /dev/null)
 DOCKER = $(shell docker ps 2> /dev/null)
-NPM = $(shell which npm 2> /dev/null)
 COMPOSER = ${PHP} ./composer.phar
 DOCKER_COMPOSE := $(shell which docker) compose
 MODULE ?= $(shell basename ${PWD})

--- a/_dev/README.md
+++ b/_dev/README.md
@@ -1,29 +1,45 @@
-# ps_accounts
+# ps_accounts — front
 
-## Project setup
+Sources TypeScript des deux apps front du module (`apps/login`, `apps/notifications`),
+compilées par Vite en librairies ES vers `../views/js/` et `../views/css/`.
+
+## Prérequis
+
+Node **24** (voir `.nvmrc` à la racine du dépôt) et pnpm **10+**.
 
 ```
-npm install
+nvm use
 ```
 
-### Compiles and hot-reloads for development
+## Installation
 
 ```
-pnpm run serve
+pnpm install --frozen-lockfile
 ```
 
-### Compiles and minifies for production
+## Build de production
+
+Compile les deux apps. C'est ce que lance la CI de release et `make build-front`
+depuis la racine.
 
 ```
 pnpm run build
 ```
 
-### Lints and fixes files
+Chaque app peut être construite séparément :
+
+```
+pnpm run build:login
+pnpm run build:notifications
+```
+
+## Lint
 
 ```
 pnpm run lint
 ```
 
-### Customize configuration
-
-See [Configuration Reference](https://cli.vuejs.org/config/).
+> ⚠️ `lint` et `lint:fix` sont actuellement inopérants : ESLint 9 attend une
+> « flat config » (`eslint.config.js`) alors que le projet n'a qu'un
+> `.eslintrc.js` hérité, et l'option `--ext` a été supprimée. La migration est
+> à faire.

--- a/_dev/package.json
+++ b/_dev/package.json
@@ -33,7 +33,7 @@
   "author": "PrestaShop",
   "license": "AFL-3.0",
   "engines": {
-    "npm": ">=6.14.0",
-    "node": ">=24"
+    "node": ">=24",
+    "pnpm": ">=10"
   }
 }

--- a/_dev/pnpm-lock.yaml
+++ b/_dev/pnpm-lock.yaml
@@ -627,8 +627,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001692:
-    resolution: {integrity: sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1703,7 +1703,7 @@ snapshots:
   autoprefixer@10.4.20(postcss@8.5.1):
     dependencies:
       browserslist: 4.24.4
-      caniuse-lite: 1.0.30001692
+      caniuse-lite: 1.0.30001810
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -1729,7 +1729,7 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001692
+      caniuse-lite: 1.0.30001810
       electron-to-chromium: 1.5.82
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
@@ -1738,7 +1738,7 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001692: {}
+  caniuse-lite@1.0.30001810: {}
 
   chalk@4.1.2:
     dependencies:

--- a/_dev/tailwind.config.js
+++ b/_dev/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   prefix: 'psacc-',
   presets: [puikTailwindPreset],
-  content: ["./apps/**/*.vue", "./apps/**/*.css", "../views/templates/admin/**/*.tpl"],
+  content: ["./apps/**/*.ts", "./apps/**/*.css", "../views/templates/admin/**/*.tpl"],
   theme: {
     extend: {
       colors: {

--- a/_dev/tsconfig.node.json
+++ b/_dev/tsconfig.node.json
@@ -5,5 +5,5 @@
       "moduleResolution": "Node",
       "allowSyntheticDefaultImports": true
     },
-    "include": ["vite.config.ts"]
+    "include": ["vite.login.config.ts", "vite.notifications.config.ts"]
   }

--- a/_dev/vite.login.config.ts
+++ b/_dev/vite.login.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     alias: [
       {
         find: "@",
-        replacement: path.resolve(__dirname, "/apps"),
+        replacement: path.resolve(__dirname, "apps"),
       },
     ],
   },

--- a/_dev/vite.notifications.config.ts
+++ b/_dev/vite.notifications.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     alias: [
       {
         find: "@",
-        replacement: path.resolve(__dirname, "/apps"),
+        replacement: path.resolve(__dirname, "apps"),
       },
     ],
   },


### PR DESCRIPTION
> 📚 **PR empilée sur #657** — base = `feature/node-24-dev-align-accounts`, pas `main`. À merger après #657 (GitHub rebasera automatiquement la base sur `main` à ce moment-là). Les deux touchent `_dev/package.json`, d'où l'empilement plutôt qu'un branchement parallèle.

## Contexte

Nettoyage remonté en instrumentant `_dev/` pour l'alignement Node 24. **Rien ici ne cassait le build** — c'est précisément pour ça que ça a survécu — mais chaque point encode une affirmation qui n'est plus vraie (Vue retiré par `185e0f34`, yarn→pnpm par `e54f5830`).

## `.gitignore`

`./_dev/.npmrc` ne matchait **rien** : un motif à `/` médian est ancré au répertoire du `.gitignore`, donc le `./` en tête réclame un dossier littéralement nommé `.`.

⚠️ **Ne pas le « corriger » en `_dev/.npmrc`** : ce fichier est tracké à dessein, il porte `@prestashopcorp:registry` et l'interpolation `${NPM_AUTH_TOKEN}` dont la CI de release dépend. Remplacé par les variantes de surcharge locale, que rien ne couvrait.

## Références mortes

| Fichier | Problème |
|---|---|
| `vite.login.config.ts` · `vite.notifications.config.ts` | l'alias `@` valait `path.resolve(__dirname, "/apps")` → `"/apps"` : un second argument absolu écrase `__dirname`. Latent, rien n'importe via `@` aujourd'hui. |
| `tsconfig.node.json` | `include: ["vite.config.ts"]`, fichier inexistant. |
| `tailwind.config.js` | globait `./apps/**/*.vue` (zéro `.vue`) en laissant les entrypoints `.ts` **non couverts** — Tailwind aurait supprimé silencieusement toute classe `psacc-*` écrite en TypeScript. |

## Docs toolchain

- `engines` : `npm: ">=6.14.0"` retiré — auto-contradictoire à côté de `node: ">=24"` (npm 6 est livré avec Node 12/14) sur un projet pnpm-only. Remplacé par `pnpm: ">=10"`, comme `accounts`.
- `_dev/README.md` : documentait `npm install` et un script `pnpm run serve` **inexistant**, avec un lien vers la doc Vue CLI. Réécrit autour des vrais scripts, avec le prérequis Node 24 et une note sur le lint cassé.
- `Makefile` : variable `NPM` jamais expansée.
- Mentions « Vue 3 » dans `CLAUDE.md` et `claude-review.yml`.
- Données browserslist vieilles de 20 mois (commit séparé — le seul qui pouvait légitimement changer les octets livrés ; il ne le fait pas, `No target browser changes`).

## Vérifications

- **Les trois assets livrés sont identiques au bit** après rebuild (`views/js/login.js`, `views/js/notifications.js`, `views/css/login.css`).
- `tsc --noEmit` : exit 0.
- `git check-ignore` matche désormais `_dev/.npmrc2`, tandis que `_dev/.npmrc` reste tracké.
- **L'alias `@` a été prouvé résolvant** par un import jetable : `1 → 5 modules transformed`, puis retiré et l'artefact reconstruit.
- Lockfile : `caniuse-lite` seul paquet touché ; pnpm 10.31.0 l'accepte en `--frozen-lockfile` sur arbre vierge.

## Volontairement hors périmètre

Les deux trop gros pour cette passe :
- **ESLint est entièrement mort** — `pnpm lint` *et* `lint:fix`. ESLint 9 est en flat config par défaut, il n'y a aucun `eslint.config.*`, donc `.eslintrc.js` n'est même pas lu (`Invalid option '--ext'`). La migration fera surgir un volume d'erreurs inconnu.
- **Le script `dev` est cassé** : pas de `vite.config.ts`, et `index.html` pointe un `/src/main.js` inexistant. Le réparer est un choix de conception (supprimer `dev` + `index.html`, ou écrire une vraie config de dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)